### PR TITLE
Enable Linux compilation and tests

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -258,7 +258,8 @@ mod tests {
             assert!(
                 config_local_dir
                     .to_string_lossy()
-                    .contains(&unique_app_name)
+                    .to_lowercase()
+                    .contains(&unique_app_name.to_lowercase())
             );
             // Cleanup the test app's config directory
             if config_local_dir.exists() {

--- a/src/core/path_utils.rs
+++ b/src/core/path_utils.rs
@@ -91,7 +91,10 @@ mod tests {
         );
         assert!(path.is_dir());
         assert!(
-            path.to_string_lossy().contains(&unique_app_name),
+            path
+                .to_string_lossy()
+                .to_lowercase()
+                .contains(&unique_app_name.to_lowercase()),
             "Path should contain the app name. Path: {:?}",
             path
         );

--- a/src/core/profiles.rs
+++ b/src/core/profiles.rs
@@ -409,7 +409,9 @@ mod profile_tests {
         if let Some(parent_of_profiles) = dir_path.parent() {
             let parent_of_profiles_str = parent_of_profiles.to_string_lossy();
             assert!(
-                parent_of_profiles_str.contains(&temp_app_name),
+                parent_of_profiles_str
+                    .to_lowercase()
+                    .contains(&temp_app_name.to_lowercase()),
                 "The parent directory of '{}' ({:?}) should contain the app name '{}'",
                 PROFILES_SUBFOLDER_NAME,
                 parent_of_profiles,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,22 @@ mod core;
 #[cfg(target_os = "windows")]
 mod platform_layer;
 
+#[cfg(not(target_os = "windows"))]
+mod platform_layer {
+    #[path = "types.rs"]
+    pub mod types;
+
+    pub use types::{
+        AppEvent, CheckState, DockStyle, LabelClass, LayoutRule, MenuAction,
+        MessageSeverity, PlatformCommand, PlatformEventHandler, TreeItemDescriptor,
+        TreeItemId, WindowConfig, WindowId,
+    };
+}
+
 #[cfg(target_os = "windows")]
 mod ui_description_layer;
+
+use simplelog::{ConfigBuilder, LevelFilter};
 
 #[cfg(target_os = "windows")]
 use {
@@ -18,7 +32,6 @@ use {
         CoreTikTokenCounter, NodeStateApplicator, ProfileRuntimeData, ProfileRuntimeDataOperations,
     },
     platform_layer::{PlatformInterface, PlatformResult, WindowConfig},
-    simplelog::{ConfigBuilder, LevelFilter},
     std::sync::{Arc, Mutex},
 };
 


### PR DESCRIPTION
## Summary
- re-export platform types on non-Windows targets
- import logging types unconditionally
- make tests case‑insensitive for config paths

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68497c35bba0832c936aa63e97065820