### PR TITLE
Refactor window handle field

### DIFF
--- a/src/platform_layer/app.rs
+++ b/src/platform_layer/app.rs
@@ -355,20 +355,7 @@ impl PlatformInterface {
         let window_id = self.internal_state.generate_unique_window_id();
 
         // Create a preliminary NativeWindowData. It will be fully populated after HWND creation.
-        let preliminary_native_data = window_common::NativeWindowData {
-            this_window_hwnd: window_common::HWND_INVALID, // HWND is not yet known
-            logical_window_id: window_id,
-            treeview_state: None, // TreeView specific state
-            control_hwnd_map: HashMap::new(),
-            // status_bar_current_text: String::new(), // Removed as per previous phase
-            // status_bar_current_severity: MessageSeverity::None, // Removed
-            menu_action_map: HashMap::new(),
-            next_menu_item_id_counter: 30000, // Initial value for menu item IDs
-            layout_rules: None,
-            label_severities: HashMap::new(), // For new status labels
-            input_bg_colors: HashMap::new(),
-            status_bar_font: None,            // Font for status bar labels
-        };
+        let preliminary_native_data = window_common::NativeWindowData::new(window_id);
 
         // Insert preliminary data before creating the native window.
         // This ensures that if WM_NCCREATE is processed for this window_id,
@@ -428,7 +415,7 @@ impl PlatformInterface {
         match self.internal_state.active_windows.write() {
             Ok(mut windows_map_guard) => {
                 if let Some(window_data) = windows_map_guard.get_mut(&window_id) {
-                    window_data.this_window_hwnd = hwnd; // Set the actual HWND
+                    window_data.set_hwnd(hwnd); // Set the actual HWND
                     log::debug!(
                         "Platform: Updated HWND in NativeWindowData for WindowId {:?}.",
                         window_id,

--- a/src/platform_layer/command_executor.rs
+++ b/src/platform_layer/command_executor.rs
@@ -134,7 +134,7 @@ pub(crate) fn execute_signal_main_window_ui_setup_complete(
                     window_id
                 ))
             })?
-            .this_window_hwnd
+            .get_hwnd()
     };
 
     if hwnd_target.is_invalid() {
@@ -213,8 +213,8 @@ pub(crate) fn execute_create_main_menu(
             ))
         })?;
 
-        hwnd_owner_opt = Some(window_data.this_window_hwnd);
-        if window_data.this_window_hwnd.is_invalid() {
+        hwnd_owner_opt = Some(window_data.get_hwnd());
+        if window_data.get_hwnd().is_invalid() {
             unsafe {
                 DestroyMenu(h_main_menu).unwrap_or_default();
             }
@@ -445,7 +445,7 @@ pub(crate) fn execute_create_button(
         )));
     }
 
-    if window_data.this_window_hwnd.is_invalid() {
+    if window_data.get_hwnd().is_invalid() {
         log::error!(
             "CommandExecutor: Parent HWND for CreateButton is invalid (WinID: {:?})",
             window_id
@@ -466,7 +466,7 @@ pub(crate) fn execute_create_button(
             0,
             10,
             10, // Dummies, WM_SIZE/LayoutRules will adjust
-            Some(window_data.this_window_hwnd),
+            Some(window_data.get_hwnd()),
             Some(HMENU(control_id as *mut _)), // Use logical ID for HMENU
             Some(internal_state.h_instance),
             None,
@@ -613,7 +613,7 @@ pub(crate) fn execute_create_input(
                 id, window_id
             ))
         })?,
-        None => window_data.this_window_hwnd,
+        None => window_data.get_hwnd(),
     };
 
     if hwnd_parent.is_invalid() {
@@ -878,7 +878,7 @@ pub(crate) fn execute_create_panel(
                 id, window_id
             ))
         })?,
-        None => window_data.this_window_hwnd, // Parent is the main window
+        None => window_data.get_hwnd(), // Parent is the main window
     };
 
     if hwnd_parent.is_invalid() {

--- a/src/platform_layer/command_executor_tests.rs
+++ b/src/platform_layer/command_executor_tests.rs
@@ -30,18 +30,7 @@ fn setup_test_env() -> (Arc<Win32ApiInternalState>, WindowId, NativeWindowData) 
     let internal_state_arc = Win32ApiInternalState::new("TestAppForExecutor".to_string()).unwrap();
     let window_id = internal_state_arc.generate_window_id();
 
-    let native_window_data = NativeWindowData {
-        this_window_hwnd: window_common::HWND_INVALID,
-        logical_window_id: window_id,
-        treeview_state: None,
-        control_hwnd_map: HashMap::new(),
-        menu_action_map: HashMap::new(),
-        next_menu_item_id_counter: 30000,
-        layout_rules: None,
-        label_severities: HashMap::new(),
-        input_bg_colors: HashMap::new(),
-        status_bar_font: None,
-    };
+    let native_window_data = NativeWindowData::new(window_id);
     (internal_state_arc, window_id, native_window_data)
 }
 #[cfg(test)]

--- a/src/platform_layer/controls/treeview_handler.rs
+++ b/src/platform_layer/controls/treeview_handler.rs
@@ -230,7 +230,7 @@ pub(crate) fn handle_create_treeview_command(
                 control_id, window_id
             )));
         }
-        hwnd_parent_for_creation = window_data.this_window_hwnd;
+        hwnd_parent_for_creation = window_data.get_hwnd();
         h_instance_for_creation = internal_state.h_instance;
 
         if hwnd_parent_for_creation.is_invalid() {

--- a/src/platform_layer/dialog_handler.rs
+++ b/src/platform_layer/dialog_handler.rs
@@ -54,7 +54,7 @@ pub(crate) fn get_hwnd_owner(
     })?;
     windows_guard
         .get(&window_id)
-        .map(|data| data.this_window_hwnd)
+        .map(|data| data.get_hwnd())
         .ok_or_else(|| {
             PlatformError::InvalidHandle(format!(
                 "WindowId {:?} not found for get_hwnd_owner",

--- a/src/platform_layer/window_common.rs
+++ b/src/platform_layer/window_common.rs
@@ -80,7 +80,7 @@ const SUCCESS_CODE: LRESULT = LRESULT(0);
  */
 #[derive(Debug)]
 pub(crate) struct NativeWindowData {
-    pub(crate) this_window_hwnd: HWND,
+    this_window_hwnd: HWND,
     pub(crate) logical_window_id: WindowId,
     // The specific internal state for the TreeView control if one exists.
     pub(crate) treeview_state: Option<treeview_handler::TreeViewInternalState>,
@@ -101,6 +101,29 @@ pub(crate) struct NativeWindowData {
 }
 
 impl NativeWindowData {
+    pub(crate) fn new(logical_window_id: WindowId) -> Self {
+        Self {
+            this_window_hwnd: HWND_INVALID,
+            logical_window_id,
+            treeview_state: None,
+            control_hwnd_map: HashMap::new(),
+            menu_action_map: HashMap::new(),
+            next_menu_item_id_counter: 30000,
+            layout_rules: None,
+            label_severities: HashMap::new(),
+            input_bg_colors: HashMap::new(),
+            status_bar_font: None,
+        }
+    }
+
+    pub(crate) fn get_hwnd(&self) -> HWND {
+        self.this_window_hwnd
+    }
+
+    pub(crate) fn set_hwnd(&mut self, hwnd: HWND) {
+        self.this_window_hwnd = hwnd;
+    }
+
     pub(crate) fn get_control_hwnd(&self, control_id: i32) -> Option<HWND> {
         self.control_hwnd_map.get(&control_id).copied()
     }


### PR DESCRIPTION
## Summary
- hide `this_window_hwnd` inside `NativeWindowData`
- provide `new`, `get_hwnd` and `set_hwnd` helpers
- update modules to use new helpers

## Testing
- `cargo check`
- `cargo test`
- `rustup component add rustfmt` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_684b23283db0832cac35dfe7a4de6f2b