### PR TITLE
Refactor: make Win32ApiInternalState.h_instance private

### DIFF
--- a/doc/PLan.MainDevelopment.md
+++ b/doc/PLan.MainDevelopment.md
@@ -36,6 +36,9 @@ This section details various cleanup tasks, refactorings, and minor enhancements
 
 # Phase 3: Enhancements & UX Improvements
 
+## P3.2: Quick search visual enhancement
+*   When doing a quick search, the text matching should be highlighted.
+
 ## P3.3: File Content Viewer (preview)
 *   Add a read-only text control. `[UiContentViewerPanelReadOnlyV1]`
 *   Load selected file's content into the viewer.

--- a/src/platform_layer/app.rs
+++ b/src/platform_layer/app.rs
@@ -33,9 +33,9 @@ use std::sync::{
  */
 pub(crate) struct Win32ApiInternalState {
     h_instance: HINSTANCE,
-    active_windows: RwLock<HashMap<WindowId, window_common::NativeWindowData>>,
+    next_window_id_counter: AtomicUsize, // For generating unique WindowIds
     // Central registry for all active windows, mapping WindowId to its native state.
-    pub(crate) active_windows: RwLock<HashMap<WindowId, window_common::NativeWindowData>>,
+    active_windows: RwLock<HashMap<WindowId, window_common::NativeWindowData>>,
     pub(crate) application_event_handler: Mutex<Option<Weak<Mutex<dyn PlatformEventHandler>>>>,
     // The application name, used for window class registration.
     pub(crate) app_name_for_class: String,

--- a/src/platform_layer/app.rs
+++ b/src/platform_layer/app.rs
@@ -33,7 +33,7 @@ use std::sync::{
  */
 pub(crate) struct Win32ApiInternalState {
     h_instance: HINSTANCE,
-    next_window_id_counter: AtomicUsize, // For generating unique WindowIds
+    active_windows: RwLock<HashMap<WindowId, window_common::NativeWindowData>>,
     // Central registry for all active windows, mapping WindowId to its native state.
     pub(crate) active_windows: RwLock<HashMap<WindowId, window_common::NativeWindowData>>,
     pub(crate) application_event_handler: Mutex<Option<Weak<Mutex<dyn PlatformEventHandler>>>>,
@@ -120,6 +120,16 @@ impl Win32ApiInternalState {
      */
     pub(crate) fn h_instance(&self) -> HINSTANCE {
         self.h_instance
+    }
+
+    /*
+     * Returns a reference to the map of active windows.
+     * External modules use this to acquire read or write locks on the map.
+     */
+    pub(crate) fn active_windows(
+        &self,
+    ) -> &RwLock<HashMap<WindowId, window_common::NativeWindowData>> {
+        &self.active_windows
     }
 
     /*

--- a/src/platform_layer/app.rs
+++ b/src/platform_layer/app.rs
@@ -32,7 +32,7 @@ use std::sync::{
  * TOOD: I think all member should be made private here. Instead, accessor functions should be provided.
  */
 pub(crate) struct Win32ApiInternalState {
-    pub(crate) h_instance: HINSTANCE,
+    h_instance: HINSTANCE,
     pub(crate) next_window_id_counter: AtomicUsize, // For generating unique WindowIds
     // Central registry for all active windows, mapping WindowId to its native state.
     pub(crate) active_windows: RwLock<HashMap<WindowId, window_common::NativeWindowData>>,
@@ -112,6 +112,14 @@ impl Win32ApiInternalState {
             );
             unsafe { PostQuitMessage(0) };
         }
+    }
+
+    /*
+     * Retrieves the application's instance handle.
+     * Control and window creation functions use this value when calling Win32 APIs.
+     */
+    pub(crate) fn h_instance(&self) -> HINSTANCE {
+        self.h_instance
     }
 
     /*

--- a/src/platform_layer/app.rs
+++ b/src/platform_layer/app.rs
@@ -33,7 +33,7 @@ use std::sync::{
  */
 pub(crate) struct Win32ApiInternalState {
     h_instance: HINSTANCE,
-    pub(crate) next_window_id_counter: AtomicUsize, // For generating unique WindowIds
+    next_window_id_counter: AtomicUsize, // For generating unique WindowIds
     // Central registry for all active windows, mapping WindowId to its native state.
     pub(crate) active_windows: RwLock<HashMap<WindowId, window_common::NativeWindowData>>,
     pub(crate) application_event_handler: Mutex<Option<Weak<Mutex<dyn PlatformEventHandler>>>>,
@@ -239,10 +239,7 @@ impl Win32ApiInternalState {
                 control_id,
                 text,
             } => super::controls::button_handler::handle_create_button_command(
-                self,
-                window_id,
-                control_id,
-                text,
+                self, window_id, control_id, text,
             ),
             PlatformCommand::CreateTreeView {
                 window_id,
@@ -290,20 +287,14 @@ impl Win32ApiInternalState {
             } => treeview_handler::handle_redraw_tree_item_command(
                 self, window_id, control_id, item_id,
             ),
-            PlatformCommand::ExpandVisibleTreeItems { window_id, control_id } => {
-                command_executor::execute_expand_visible_tree_items(
-                    self,
-                    window_id,
-                    control_id,
-                )
-            }
-            PlatformCommand::ExpandAllTreeItems { window_id, control_id } => {
-                command_executor::execute_expand_all_tree_items(
-                    self,
-                    window_id,
-                    control_id,
-                )
-            }
+            PlatformCommand::ExpandVisibleTreeItems {
+                window_id,
+                control_id,
+            } => command_executor::execute_expand_visible_tree_items(self, window_id, control_id),
+            PlatformCommand::ExpandAllTreeItems {
+                window_id,
+                control_id,
+            } => command_executor::execute_expand_all_tree_items(self, window_id, control_id),
             PlatformCommand::CreateInput {
                 window_id,
                 parent_control_id,
@@ -325,7 +316,9 @@ impl Win32ApiInternalState {
                 window_id,
                 control_id,
                 color,
-            } => command_executor::execute_set_input_background_color(self, window_id, control_id, color),
+            } => command_executor::execute_set_input_background_color(
+                self, window_id, control_id, color,
+            ),
         }
     }
 }

--- a/src/platform_layer/app.rs
+++ b/src/platform_layer/app.rs
@@ -58,10 +58,7 @@ impl Win32ApiInternalState {
         self.h_instance
     }
 
-    /*
-     * Returns a reference to the map of active windows.
-     * External modules use this to acquire read or write locks on the map.
-     */
+    #[cfg(test)]
     pub(crate) fn active_windows(
         &self,
     ) -> &RwLock<HashMap<WindowId, window_common::NativeWindowData>> {

--- a/src/platform_layer/command_executor.rs
+++ b/src/platform_layer/command_executor.rs
@@ -41,7 +41,7 @@ pub(crate) fn execute_define_layout(
         rules.len()
     );
 
-    let mut windows_map_guard = internal_state.active_windows.write().map_err(|e| {
+    let mut windows_map_guard = internal_state.active_windows().write().map_err(|e| {
         log::error!(
             "CommandExecutor: Failed to lock windows map for execute_define_layout: {:?}",
             e
@@ -112,7 +112,7 @@ pub(crate) fn execute_signal_main_window_ui_setup_complete(
     // custom message to the window. The window procedure will translate it into
     // `AppEvent::MainWindowUISetupComplete`.
     let hwnd_target = {
-        let windows_guard = internal_state.active_windows.read().map_err(|e| {
+        let windows_guard = internal_state.active_windows().read().map_err(|e| {
             log::error!(
                 "CommandExecutor: Failed to lock windows map to post UI setup complete: {:?}",
                 e
@@ -193,7 +193,7 @@ pub(crate) fn execute_create_main_menu(
 
     {
         // Scope for write lock
-        let mut windows_map_guard = internal_state.active_windows.write().map_err(|e|{
+        let mut windows_map_guard = internal_state.active_windows().write().map_err(|e|{
             log::error!("CommandExecutor: Failed to lock windows map for main menu creation (data population): {:?}", e);
             PlatformError::OperationFailed("Failed to lock windows map for main menu creation (data population)".into())
         })?;
@@ -347,7 +347,7 @@ pub(crate) fn execute_set_control_enabled(
         control_id,
         enabled
     );
-    let windows_guard = internal_state.active_windows.read().map_err(|e|{
+    let windows_guard = internal_state.active_windows().read().map_err(|e|{
         log::error!("CommandExecutor: Failed to acquire read lock on windows map for SetControlEnabled: {:?}", e);
         PlatformError::OperationFailed("Failed to acquire read lock on windows map for SetControlEnabled".into())
     })?;
@@ -478,7 +478,7 @@ pub(crate) fn execute_create_input(
         control_id
     );
 
-    let mut windows_guard = internal_state.active_windows.write().map_err(|e| {
+    let mut windows_guard = internal_state.active_windows().write().map_err(|e| {
         log::error!(
             "CommandExecutor: Failed to lock windows map for CreateInput: {:?}",
             e
@@ -571,7 +571,7 @@ pub(crate) fn execute_set_input_text(
     text: String,
 ) -> PlatformResult<()> {
     let hwnd_edit = {
-        let windows_guard = internal_state.active_windows.read().map_err(|e| {
+        let windows_guard = internal_state.active_windows().read().map_err(|e| {
             log::error!(
                 "CommandExecutor: Failed to lock windows map for SetInputText: {:?}",
                 e
@@ -628,7 +628,7 @@ pub(crate) fn execute_set_input_background_color(
 ) -> PlatformResult<()> {
     let hwnd_edit;
     {
-        let mut windows_guard = internal_state.active_windows.write().map_err(|e| {
+        let mut windows_guard = internal_state.active_windows().write().map_err(|e| {
             log::error!(
                 "CommandExecutor: Failed to lock windows map for SetInputBackgroundColor: {:?}",
                 e
@@ -746,7 +746,7 @@ pub(crate) fn execute_create_panel(
         parent_control_id
     );
 
-    let mut windows_map_guard = internal_state.active_windows.write().map_err(|e| {
+    let mut windows_map_guard = internal_state.active_windows().write().map_err(|e| {
         log::error!(
             "CommandExecutor: Failed to lock windows map for CreatePanel: {:?}",
             e

--- a/src/platform_layer/command_executor.rs
+++ b/src/platform_layer/command_executor.rs
@@ -546,7 +546,7 @@ pub(crate) fn execute_create_input(
             10,
             Some(hwnd_parent),
             Some(HMENU(control_id as usize as *mut std::ffi::c_void)),
-            Some(internal_state.h_instance),
+            Some(internal_state.h_instance()),
             None,
         )?
     };
@@ -812,7 +812,7 @@ pub(crate) fn execute_create_panel(
             10, // Dummy position/size, layout rules will adjust
             Some(hwnd_parent),
             Some(HMENU(panel_id as *mut _)), // Use logical ID for the HMENU
-            Some(internal_state.h_instance),
+            Some(internal_state.h_instance()),
             None,
         )?
     };

--- a/src/platform_layer/command_executor.rs
+++ b/src/platform_layer/command_executor.rs
@@ -26,9 +26,8 @@ use windows::{
 
 /*
  * Executes the `DefineLayout` command.
- * This function retrieves the `NativeWindowData` for the given `window_id`
- * and stores the provided `layout_rules` within it. These rules will later
- * be used by the `WM_SIZE` handler to position controls.
+ * This function stores the provided `layout_rules` within the specified window's
+ * data and then triggers a layout recalculation to apply the new rules.
  */
 pub(crate) fn execute_define_layout(
     internal_state: &Arc<Win32ApiInternalState>,
@@ -36,42 +35,15 @@ pub(crate) fn execute_define_layout(
     rules: Vec<LayoutRule>,
 ) -> PlatformResult<()> {
     log::debug!(
-        "CommandExecutor: execute_define_layout for WinID {:?}, with {} rules.",
-        window_id,
-        rules.len()
-    );
-
-    let mut windows_map_guard = internal_state.active_windows().write().map_err(|e| {
-        log::error!(
-            "CommandExecutor: Failed to lock windows map for execute_define_layout: {:?}",
-            e
-        );
-        PlatformError::OperationFailed(
-            "Failed to lock windows map for execute_define_layout".into(),
-        )
-    })?;
-
-    let window_data = windows_map_guard.get_mut(&window_id).ok_or_else(|| {
-        log::warn!(
-            "CommandExecutor: WindowId {:?} not found for execute_define_layout storage.",
-            window_id
-        );
-        PlatformError::InvalidHandle(format!(
-            "WindowId {:?} not found for execute_define_layout storage",
-            window_id
-        ))
-    })?;
-
-    // Store the rules
-    window_data.define_layout(rules);
-    log::debug!(
-        "CommandExecutor: Stored layout rules for WinID {:?}",
+        "CommandExecutor: Storing {} layout rules for WinID {:?}.",
+        rules.len(),
         window_id
     );
 
-    // Explicitly drop the write guard before calling trigger_layout_recalculation,
-    // as trigger_layout_recalculation will take its own read lock.
-    drop(windows_map_guard);
+    internal_state.with_window_data_write(window_id, |window_data| {
+        window_data.define_layout(rules);
+        Ok(())
+    })?;
 
     // Now trigger the layout recalculation.
     internal_state.trigger_layout_recalculation(window_id);
@@ -108,33 +80,8 @@ pub(crate) fn execute_signal_main_window_ui_setup_complete(
         window_id
     );
 
-    // Defer the event until the Win32 message loop is running by posting a
-    // custom message to the window. The window procedure will translate it into
-    // `AppEvent::MainWindowUISetupComplete`.
-    let hwnd_target = {
-        let windows_guard = internal_state.active_windows().read().map_err(|e| {
-            log::error!(
-                "CommandExecutor: Failed to lock windows map to post UI setup complete: {:?}",
-                e
-            );
-            PlatformError::OperationFailed(
-                "Failed to lock windows map to post UI setup complete".into(),
-            )
-        })?;
-        windows_guard
-            .get(&window_id)
-            .ok_or_else(|| {
-                log::warn!(
-                    "CommandExecutor: WindowId {:?} not found to post UI setup complete.",
-                    window_id
-                );
-                PlatformError::InvalidHandle(format!(
-                    "WindowId {:?} not found to post UI setup complete",
-                    window_id
-                ))
-            })?
-            .get_hwnd()
-    };
+    let hwnd_target = internal_state
+        .with_window_data_read(window_id, |window_data| Ok(window_data.get_hwnd()))?;
 
     if hwnd_target.is_invalid() {
         log::warn!(
@@ -189,100 +136,46 @@ pub(crate) fn execute_create_main_menu(
         window_id
     );
     let h_main_menu = unsafe { CreateMenu()? };
-    let hwnd_owner_opt: Option<HWND>;
 
-    {
-        // Scope for write lock
-        let mut windows_map_guard = internal_state.active_windows().write().map_err(|e|{
-            log::error!("CommandExecutor: Failed to lock windows map for main menu creation (data population): {:?}", e);
-            PlatformError::OperationFailed("Failed to lock windows map for main menu creation (data population)".into())
-        })?;
-
-        let window_data = windows_map_guard.get_mut(&window_id).ok_or_else(|| {
-            unsafe {
-                DestroyMenu(h_main_menu).unwrap_or_default();
-            }
+    let hwnd_owner = internal_state.with_window_data_write(window_id, |window_data| {
+        let hwnd = window_data.get_hwnd();
+        if hwnd.is_invalid() {
             log::warn!(
-                "CommandExecutor: WindowId {:?} not found for CreateMainMenu (data population).",
-                window_id
-            );
-            PlatformError::InvalidHandle(format!(
-                "WindowId {:?} not found for CreateMainMenu (data population)",
-                window_id
-            ))
-        })?;
-
-        hwnd_owner_opt = Some(window_data.get_hwnd());
-        if window_data.get_hwnd().is_invalid() {
-            unsafe {
-                DestroyMenu(h_main_menu).unwrap_or_default();
-            }
-            log::warn!(
-                "CommandExecutor: HWND not yet valid for WindowId {:?} during menu data population.",
+                "CommandExecutor: HWND not yet valid for WindowId {:?} during menu creation.",
                 window_id
             );
             return Err(PlatformError::InvalidHandle(format!(
-                "HWND not yet valid for WindowId {:?} during menu data population",
+                "HWND not yet valid for WindowId {:?} during menu creation",
                 window_id
             )));
         }
-        for item_config in menu_items {
-            // This helper function is now part of menu_handler or command_executor itself
-            // For now, let's assume it's still here or move it if refactoring menu_handler next.
-            // Keeping it here for now for minimal change to this file beyond TreeView.
-            unsafe { add_menu_item_recursive_impl(h_main_menu, &item_config, window_data)? };
+        for item_config in &menu_items {
+            // This helper recursively populates the menu and registers actions in window_data
+            unsafe { add_menu_item_recursive_impl(h_main_menu, item_config, window_data)? };
         }
-    } // Write lock released
+        Ok(hwnd)
+    })?;
 
-    if let Some(hwnd_owner) = hwnd_owner_opt {
-        if !hwnd_owner.is_invalid() {
-            if unsafe { SetMenu(hwnd_owner, Some(h_main_menu)) }.is_err() {
-                let last_error = unsafe { GetLastError() };
-                unsafe {
-                    DestroyMenu(h_main_menu).unwrap_or_default();
-                }
-                log::error!(
-                    "CommandExecutor: SetMenu failed for main menu on WindowId {:?}: {:?}",
-                    window_id,
-                    last_error
-                );
-                return Err(PlatformError::OperationFailed(format!(
-                    "SetMenu failed for main menu on WindowId {:?}: {:?}",
-                    window_id, last_error
-                )));
-            }
-            log::debug!(
-                "CommandExecutor: Main menu created and set for WindowId {:?}",
-                window_id
-            );
-            Ok(())
-        } else {
-            unsafe {
-                DestroyMenu(h_main_menu).unwrap_or_default();
-            }
-            log::warn!(
-                "CommandExecutor: Owner HWND was invalid before SetMenu for WinID {:?}",
-                window_id
-            );
-            Err(PlatformError::InvalidHandle(format!(
-                "Owner HWND was invalid before SetMenu for WinID {:?}",
-                window_id
-            )))
-        }
-    } else {
-        // Should not happen if window_data was found and HWND was valid
+    if unsafe { SetMenu(hwnd_owner, Some(h_main_menu)) }.is_err() {
+        let last_error = unsafe { GetLastError() };
         unsafe {
             DestroyMenu(h_main_menu).unwrap_or_default();
         }
         log::error!(
-            "CommandExecutor: hwnd_owner_opt was None after lock release for WinID {:?}",
-            window_id
+            "CommandExecutor: SetMenu failed for main menu on WindowId {:?}: {:?}",
+            window_id,
+            last_error
         );
-        Err(PlatformError::OperationFailed(format!(
-            "hwnd_owner_opt was None after lock release for WinID {:?}",
-            window_id
-        )))
+        return Err(PlatformError::OperationFailed(format!(
+            "SetMenu failed for main menu on WindowId {:?}: {:?}",
+            window_id, last_error
+        )));
     }
+    log::debug!(
+        "CommandExecutor: Main menu created and set for WindowId {:?}",
+        window_id
+    );
+    Ok(())
 }
 
 /*
@@ -347,32 +240,18 @@ pub(crate) fn execute_set_control_enabled(
         control_id,
         enabled
     );
-    let windows_guard = internal_state.active_windows().read().map_err(|e|{
-        log::error!("CommandExecutor: Failed to acquire read lock on windows map for SetControlEnabled: {:?}", e);
-        PlatformError::OperationFailed("Failed to acquire read lock on windows map for SetControlEnabled".into())
-    })?;
-
-    let window_data = windows_guard.get(&window_id).ok_or_else(|| {
-        log::warn!(
-            "CommandExecutor: WindowId {:?} not found for SetControlEnabled.",
-            window_id
-        );
-        PlatformError::InvalidHandle(format!(
-            "WindowId {:?} not found for SetControlEnabled",
-            window_id
-        ))
-    })?;
-
-    let hwnd_ctrl = window_data.get_control_hwnd(control_id).ok_or_else(|| {
-        log::warn!(
-            "CommandExecutor: Control ID {} not found in window {:?} for SetControlEnabled.",
-            control_id,
-            window_id
-        );
-        PlatformError::InvalidHandle(format!(
-            "Control ID {} not found in window {:?} for SetControlEnabled",
-            control_id, window_id
-        ))
+    let hwnd_ctrl = internal_state.with_window_data_read(window_id, |window_data| {
+        window_data.get_control_hwnd(control_id).ok_or_else(|| {
+            log::warn!(
+                "CommandExecutor: Control ID {} not found in window {:?} for SetControlEnabled.",
+                control_id,
+                window_id
+            );
+            PlatformError::InvalidHandle(format!(
+                "Control ID {} not found in window {:?} for SetControlEnabled",
+                control_id, window_id
+            ))
+        })
     })?;
 
     if unsafe { EnableWindow(hwnd_ctrl, enabled) }.as_bool() == false {
@@ -478,87 +357,71 @@ pub(crate) fn execute_create_input(
         control_id
     );
 
-    let mut windows_guard = internal_state.active_windows().write().map_err(|e| {
-        log::error!(
-            "CommandExecutor: Failed to lock windows map for CreateInput: {:?}",
-            e
-        );
-        PlatformError::OperationFailed("Failed to lock windows map for CreateInput".into())
-    })?;
-
-    let window_data = windows_guard.get_mut(&window_id).ok_or_else(|| {
-        log::warn!(
-            "CommandExecutor: WindowId {:?} not found for CreateInput",
-            window_id
-        );
-        PlatformError::InvalidHandle(format!(
-            "WindowId {:?} not found for CreateInput",
-            window_id
-        ))
-    })?;
-
-    if window_data.has_control(control_id) {
-        log::warn!(
-            "CommandExecutor: Input with logical ID {} already exists for window {:?}",
-            control_id,
-            window_id
-        );
-        return Err(PlatformError::OperationFailed(format!(
-            "Input with logical ID {} already exists for window {:?}",
-            control_id, window_id
-        )));
-    }
-
-    let hwnd_parent = match parent_control_id {
-        Some(id) => window_data.get_control_hwnd(id).ok_or_else(|| {
+    internal_state.with_window_data_write(window_id, |window_data| {
+        if window_data.has_control(control_id) {
             log::warn!(
+                "CommandExecutor: Input with logical ID {} already exists for window {:?}",
+                control_id,
+                window_id
+            );
+            return Err(PlatformError::OperationFailed(format!(
+                "Input with logical ID {} already exists for window {:?}",
+                control_id, window_id
+            )));
+        }
+
+        let hwnd_parent = match parent_control_id {
+            Some(id) => window_data.get_control_hwnd(id).ok_or_else(|| {
+                log::warn!(
                 "CommandExecutor: Parent control with ID {} not found for CreateInput in WinID {:?}",
                 id, window_id
             );
-            PlatformError::InvalidHandle(format!(
-                "Parent control with ID {} not found for CreateInput in WinID {:?}",
-                id, window_id
-            ))
-        })?,
-        None => window_data.get_hwnd(),
-    };
+                PlatformError::InvalidHandle(format!(
+                    "Parent control with ID {} not found for CreateInput in WinID {:?}",
+                    id, window_id
+                ))
+            })?,
+            None => window_data.get_hwnd(),
+        };
 
-    if hwnd_parent.is_invalid() {
-        log::error!(
-            "CommandExecutor: Parent HWND invalid for CreateInput (WinID {:?})",
-            window_id
+        if hwnd_parent.is_invalid() {
+            log::error!(
+                "CommandExecutor: Parent HWND invalid for CreateInput (WinID {:?})",
+                window_id
+            );
+            return Err(PlatformError::InvalidHandle(format!(
+                "Parent HWND invalid for CreateInput (WinID {:?})",
+                window_id
+            )));
+        }
+
+        let h_instance = internal_state.h_instance();
+        let hwnd_edit = unsafe {
+            CreateWindowExW(
+                WINDOW_EX_STYLE(0),
+                WC_EDITW,
+                &HSTRING::from(initial_text.as_str()),
+                WS_CHILD | WS_VISIBLE | WS_BORDER | WINDOW_STYLE(ES_AUTOHSCROLL as u32),
+                0,
+                0,
+                10,
+                10,
+                Some(hwnd_parent),
+                Some(HMENU(control_id as usize as *mut std::ffi::c_void)),
+                Some(h_instance),
+                None,
+            )?
+        };
+
+        window_data.register_control_hwnd(control_id, hwnd_edit);
+        log::debug!(
+            "CommandExecutor: Created input field (ID {}) for WinID {:?} with HWND {:?}",
+            control_id,
+            window_id,
+            hwnd_edit
         );
-        return Err(PlatformError::InvalidHandle(format!(
-            "Parent HWND invalid for CreateInput (WinID {:?})",
-            window_id
-        )));
-    }
-
-    let hwnd_edit = unsafe {
-        CreateWindowExW(
-            WINDOW_EX_STYLE(0),
-            WC_EDITW,
-            &HSTRING::from(initial_text.as_str()),
-            WS_CHILD | WS_VISIBLE | WS_BORDER | WINDOW_STYLE(ES_AUTOHSCROLL as u32),
-            0,
-            0,
-            10,
-            10,
-            Some(hwnd_parent),
-            Some(HMENU(control_id as usize as *mut std::ffi::c_void)),
-            Some(internal_state.h_instance()),
-            None,
-        )?
-    };
-
-    window_data.register_control_hwnd(control_id, hwnd_edit);
-    log::debug!(
-        "CommandExecutor: Created input field (ID {}) for WinID {:?} with HWND {:?}",
-        control_id,
-        window_id,
-        hwnd_edit
-    );
-    Ok(())
+        Ok(())
+    })
 }
 
 /*
@@ -570,24 +433,7 @@ pub(crate) fn execute_set_input_text(
     control_id: i32,
     text: String,
 ) -> PlatformResult<()> {
-    let hwnd_edit = {
-        let windows_guard = internal_state.active_windows().read().map_err(|e| {
-            log::error!(
-                "CommandExecutor: Failed to lock windows map for SetInputText: {:?}",
-                e
-            );
-            PlatformError::OperationFailed("Failed to lock windows map".into())
-        })?;
-        let window_data = windows_guard.get(&window_id).ok_or_else(|| {
-            log::warn!(
-                "CommandExecutor: WindowId {:?} not found for SetInputText",
-                window_id
-            );
-            PlatformError::InvalidHandle(format!(
-                "WindowId {:?} not found for SetInputText",
-                window_id
-            ))
-        })?;
+    let hwnd_edit = internal_state.with_window_data_read(window_id, |window_data| {
         window_data.get_control_hwnd(control_id).ok_or_else(|| {
             log::warn!(
                 "CommandExecutor: Control ID {} not found for SetInputText in WinID {:?}",
@@ -598,8 +444,8 @@ pub(crate) fn execute_set_input_text(
                 "Control ID {} not found for SetInputText in WinID {:?}",
                 control_id, window_id
             ))
-        })?
-    };
+        })
+    })?;
 
     unsafe {
         SetWindowTextW(hwnd_edit, &HSTRING::from(text.as_str())).map_err(|e| {
@@ -626,26 +472,12 @@ pub(crate) fn execute_set_input_background_color(
     control_id: i32,
     color: Option<u32>,
 ) -> PlatformResult<()> {
-    let hwnd_edit;
-    {
-        let mut windows_guard = internal_state.active_windows().write().map_err(|e| {
-            log::error!(
-                "CommandExecutor: Failed to lock windows map for SetInputBackgroundColor: {:?}",
-                e
-            );
-            PlatformError::OperationFailed("Failed to lock windows map".into())
-        })?;
-        let window_data = windows_guard.get_mut(&window_id).ok_or_else(|| {
-            log::warn!(
-                "CommandExecutor: WindowId {:?} not found for SetInputBackgroundColor",
-                window_id
-            );
-            PlatformError::InvalidHandle(format!(
-                "WindowId {:?} not found for SetInputBackgroundColor",
-                window_id
-            ))
-        })?;
-        hwnd_edit = window_data.get_control_hwnd(control_id).ok_or_else(|| {
+    let hwnd_edit = internal_state.with_window_data_write(window_id, |window_data| {
+        // Store the new color state, this also handles cleanup of old GDI objects.
+        window_data.set_input_background_color(control_id, color)?;
+
+        // Return the HWND for invalidation.
+        window_data.get_control_hwnd(control_id).ok_or_else(|| {
             log::warn!(
                 "CommandExecutor: Control ID {} not found for SetInputBackgroundColor in WinID {:?}",
                 control_id,
@@ -655,10 +487,10 @@ pub(crate) fn execute_set_input_background_color(
                 "Control ID {} not found for SetInputBackgroundColor in WinID {:?}",
                 control_id, window_id
             ))
-        })?;
-        window_data.set_input_background_color(control_id, color)?;
-    }
+        })
+    })?;
 
+    // Trigger a repaint for the new color to take effect.
     unsafe {
         _ = InvalidateRect(Some(hwnd_edit), None, true);
     }
@@ -746,86 +578,70 @@ pub(crate) fn execute_create_panel(
         parent_control_id
     );
 
-    let mut windows_map_guard = internal_state.active_windows().write().map_err(|e| {
-        log::error!(
-            "CommandExecutor: Failed to lock windows map for CreatePanel: {:?}",
-            e
-        );
-        PlatformError::OperationFailed("Failed to lock windows map for CreatePanel".into())
-    })?;
+    internal_state.with_window_data_write(window_id, |window_data| {
+        if window_data.has_control(panel_id) {
+            log::warn!(
+                "CommandExecutor: Panel with logical ID {} already exists for window {:?}.",
+                panel_id,
+                window_id
+            );
+            return Err(PlatformError::OperationFailed(format!(
+                "Panel with logical ID {} already exists for window {:?}",
+                panel_id, window_id
+            )));
+        }
 
-    let window_data = windows_map_guard.get_mut(&window_id).ok_or_else(|| {
-        log::warn!(
-            "CommandExecutor: WindowId {:?} not found for CreatePanel.",
-            window_id
-        );
-        PlatformError::InvalidHandle(format!(
-            "WindowId {:?} not found for CreatePanel",
-            window_id
-        ))
-    })?;
+        let hwnd_parent = match parent_control_id {
+            Some(id) => window_data.get_control_hwnd(id).ok_or_else(|| {
+                log::warn!("CommandExecutor: Parent control with logical ID {} not found for CreatePanel in WinID {:?}", id, window_id);
+                PlatformError::InvalidHandle(format!(
+                    "Parent control with logical ID {} not found for CreatePanel in WinID {:?}",
+                    id, window_id
+                ))
+            })?,
+            None => window_data.get_hwnd(), // Parent is the main window
+        };
 
-    if window_data.has_control(panel_id) {
-        log::warn!(
-            "CommandExecutor: Panel with logical ID {} already exists for window {:?}.",
+        if hwnd_parent.is_invalid() {
+            log::error!(
+                "CommandExecutor: Parent HWND for CreatePanel is invalid (WinID: {:?}, ParentControlID: {:?})",
+                window_id,
+                parent_control_id
+            );
+            return Err(PlatformError::InvalidHandle(format!(
+                "Parent HWND for CreatePanel is invalid (WinID: {:?}, ParentControlID: {:?})",
+                window_id, parent_control_id
+            )));
+        }
+
+        let h_instance = internal_state.h_instance();
+        let hwnd_panel = unsafe {
+            CreateWindowExW(
+                WINDOW_EX_STYLE(0), // Or WS_EX_CONTROLPARENT if it should manage tab order for children
+                super::window_common::WC_STATIC, // Using a STATIC control as a simple panel container
+                None,               // No text for a simple panel
+                WS_CHILD | WS_VISIBLE, // Basic styles for a panel
+                0,
+                0,
+                10,
+                10, // Dummy position/size, layout rules will adjust
+                Some(hwnd_parent),
+                Some(HMENU(panel_id as *mut _)), // Use logical ID for the HMENU
+                Some(h_instance),
+                None,
+            )?
+        };
+        unsafe {
+            let prev = SetWindowLongPtrW(hwnd_panel, GWLP_WNDPROC, forwarding_panel_proc as isize);
+            SetWindowLongPtrW(hwnd_panel, GWLP_USERDATA, prev);
+        }
+        window_data.register_control_hwnd(panel_id, hwnd_panel);
+        log::debug!(
+            "CommandExecutor: Created panel (LogicalID {}) for WinID {:?} with HWND {:?}",
             panel_id,
-            window_id
-        );
-        return Err(PlatformError::OperationFailed(format!(
-            "Panel with logical ID {} already exists for window {:?}",
-            panel_id, window_id
-        )));
-    }
-
-    let hwnd_parent = match parent_control_id {
-        Some(id) => window_data.get_control_hwnd(id).ok_or_else(|| {
-            log::warn!("CommandExecutor: Parent control with logical ID {} not found for CreatePanel in WinID {:?}", id, window_id);
-            PlatformError::InvalidHandle(format!(
-                "Parent control with logical ID {} not found for CreatePanel in WinID {:?}",
-                id, window_id
-            ))
-        })?,
-        None => window_data.get_hwnd(), // Parent is the main window
-    };
-
-    if hwnd_parent.is_invalid() {
-        log::error!(
-            "CommandExecutor: Parent HWND for CreatePanel is invalid (WinID: {:?}, ParentControlID: {:?})",
             window_id,
-            parent_control_id
+            hwnd_panel
         );
-        return Err(PlatformError::InvalidHandle(format!(
-            "Parent HWND for CreatePanel is invalid (WinID: {:?}, ParentControlID: {:?})",
-            window_id, parent_control_id
-        )));
-    }
-
-    let hwnd_panel = unsafe {
-        CreateWindowExW(
-            WINDOW_EX_STYLE(0), // Or WS_EX_CONTROLPARENT if it should manage tab order for children
-            super::window_common::WC_STATIC, // Using a STATIC control as a simple panel container
-            None,               // No text for a simple panel
-            WS_CHILD | WS_VISIBLE, // Basic styles for a panel
-            0,
-            0,
-            10,
-            10, // Dummy position/size, layout rules will adjust
-            Some(hwnd_parent),
-            Some(HMENU(panel_id as *mut _)), // Use logical ID for the HMENU
-            Some(internal_state.h_instance()),
-            None,
-        )?
-    };
-    unsafe {
-        let prev = SetWindowLongPtrW(hwnd_panel, GWLP_WNDPROC, forwarding_panel_proc as isize);
-        SetWindowLongPtrW(hwnd_panel, GWLP_USERDATA, prev);
-    }
-    window_data.register_control_hwnd(panel_id, hwnd_panel);
-    log::debug!(
-        "CommandExecutor: Created panel (LogicalID {}) for WinID {:?} with HWND {:?}",
-        panel_id,
-        window_id,
-        hwnd_panel
-    );
-    Ok(())
+        Ok(())
+    })
 }

--- a/src/platform_layer/command_executor_tests.rs
+++ b/src/platform_layer/command_executor_tests.rs
@@ -116,7 +116,7 @@ mod tests {
     fn test_expand_visible_tree_items_returns_error() {
         let (internal_state, window_id, native_window_data) = setup_test_env();
         {
-            let mut guard = internal_state.active_windows.write().unwrap();
+            let mut guard = internal_state.active_windows().write().unwrap();
             guard.insert(window_id, native_window_data);
         }
 
@@ -132,7 +132,7 @@ mod tests {
     fn test_expand_all_tree_items_returns_error() {
         let (internal_state, window_id, native_window_data) = setup_test_env();
         {
-            let mut guard = internal_state.active_windows.write().unwrap();
+            let mut guard = internal_state.active_windows().write().unwrap();
             guard.insert(window_id, native_window_data);
         }
 

--- a/src/platform_layer/controls/button_handler.rs
+++ b/src/platform_layer/controls/button_handler.rs
@@ -40,7 +40,7 @@ pub(crate) fn handle_create_button_command(
     let hwnd_parent_for_creation: HWND;
     let h_instance: HINSTANCE;
     {
-        let mut windows_map = internal_state.active_windows.write().map_err(|e| {
+        let mut windows_map = internal_state.active_windows().write().map_err(|e| {
             log::error!(
                 "ButtonHandler: Failed to lock windows map for CreateButton: {:?}",
                 e
@@ -103,7 +103,7 @@ pub(crate) fn handle_create_button_command(
         )?
     };
 
-    let mut windows_map = internal_state.active_windows.write().map_err(|e| {
+    let mut windows_map = internal_state.active_windows().write().map_err(|e| {
         log::error!(
             "ButtonHandler: Failed to re-lock windows map after CreateButton: {:?}",
             e

--- a/src/platform_layer/controls/button_handler.rs
+++ b/src/platform_layer/controls/button_handler.rs
@@ -10,9 +10,10 @@ use crate::platform_layer::types::{AppEvent, WindowId};
 
 use std::sync::Arc;
 use windows::Win32::{
-    Foundation::{HINSTANCE, HWND},
+    Foundation::HWND,
     UI::WindowsAndMessaging::{
-        BS_PUSHBUTTON, CreateWindowExW, HMENU, WINDOW_EX_STYLE, WINDOW_STYLE, WS_CHILD, WS_VISIBLE,
+        BS_PUSHBUTTON, CreateWindowExW, DestroyWindow, HMENU, WINDOW_EX_STYLE, WINDOW_STYLE,
+        WS_CHILD, WS_VISIBLE,
     },
 };
 use windows::core::{HSTRING, PCWSTR};
@@ -22,7 +23,13 @@ const WC_BUTTON: PCWSTR = windows::core::w!("BUTTON");
 /*
  * Creates a native push button and registers the resulting HWND in the
  * window's `NativeWindowData`. Fails if the window or control ID are
- * invalid or already in use.
+ * invalid or already in use. This function uses a read-create-write pattern
+ * to minimize lock contention on the global window map.
+ *
+ * First, it acquires a read lock to verify that the control doesn't already
+ * exist and to get the parent HWND. Then, it creates the native button
+ * control without holding any locks. Finally, it acquires a write lock briefly
+ * to register the new control, checking for race conditions.
  */
 pub(crate) fn handle_create_button_command(
     internal_state: &Arc<Win32ApiInternalState>,
@@ -37,55 +44,38 @@ pub(crate) fn handle_create_button_command(
         text
     );
 
-    let hwnd_parent_for_creation: HWND;
-    let h_instance: HINSTANCE;
-    {
-        let mut windows_map = internal_state.active_windows().write().map_err(|e| {
-            log::error!(
-                "ButtonHandler: Failed to lock windows map for CreateButton: {:?}",
-                e
-            );
-            PlatformError::OperationFailed("Failed to lock windows map for CreateButton".into())
+    // Phase 1: Read-only pre-checks.
+    // Get the parent HWND for creation while holding only a read lock.
+    let hwnd_parent_for_creation =
+        internal_state.with_window_data_read(window_id, |window_data| {
+            if window_data.has_control(control_id) {
+                log::warn!(
+                    "ButtonHandler: Button with ID {} already exists for window {:?}.",
+                    control_id,
+                    window_id
+                );
+                return Err(PlatformError::OperationFailed(format!(
+                    "Button with ID {} already exists for window {:?}",
+                    control_id, window_id
+                )));
+            }
+
+            let hwnd_parent = window_data.get_hwnd();
+            if hwnd_parent.is_invalid() {
+                log::error!(
+                    "ButtonHandler: Parent HWND invalid for CreateButton (WinID: {:?})",
+                    window_id
+                );
+                return Err(PlatformError::InvalidHandle(format!(
+                    "Parent HWND invalid for CreateButton (WinID: {:?})",
+                    window_id
+                )));
+            }
+            Ok(hwnd_parent)
         })?;
 
-        let window_data = windows_map.get_mut(&window_id).ok_or_else(|| {
-            log::warn!(
-                "ButtonHandler: WindowId {:?} not found for CreateButton.",
-                window_id
-            );
-            PlatformError::InvalidHandle(format!(
-                "WindowId {:?} not found for CreateButton",
-                window_id
-            ))
-        })?;
-
-        if window_data.has_control(control_id) {
-            log::warn!(
-                "ButtonHandler: Button with ID {} already exists for window {:?}.",
-                control_id,
-                window_id
-            );
-            return Err(PlatformError::OperationFailed(format!(
-                "Button with ID {} already exists for window {:?}",
-                control_id, window_id
-            )));
-        }
-
-        if window_data.get_hwnd().is_invalid() {
-            log::error!(
-                "ButtonHandler: Parent HWND invalid for CreateButton (WinID: {:?})",
-                window_id
-            );
-            return Err(PlatformError::InvalidHandle(format!(
-                "Parent HWND invalid for CreateButton (WinID: {:?})",
-                window_id
-            )));
-        }
-
-        hwnd_parent_for_creation = window_data.get_hwnd();
-        h_instance = internal_state.h_instance();
-    }
-
+    // Phase 2: Create the native control without holding any locks.
+    let h_instance = internal_state.h_instance();
     let hwnd_button = unsafe {
         CreateWindowExW(
             WINDOW_EX_STYLE(0),
@@ -103,15 +93,10 @@ pub(crate) fn handle_create_button_command(
         )?
     };
 
-    let mut windows_map = internal_state.active_windows().write().map_err(|e| {
-        log::error!(
-            "ButtonHandler: Failed to re-lock windows map after CreateButton: {:?}",
-            e
-        );
-        PlatformError::OperationFailed("Failed to re-lock windows map after CreateButton".into())
-    })?;
-
-    if let Some(window_data) = windows_map.get_mut(&window_id) {
+    // Phase 3: Acquire a write lock only to register the new HWND.
+    internal_state.with_window_data_write(window_id, |window_data| {
+        // Re-check for a race condition where another thread created the control
+        // while we were not holding a lock.
         if window_data.has_control(control_id) {
             log::warn!(
                 "ButtonHandler: Control ID {} was created concurrently for window {:?}. Destroying new HWND.",
@@ -119,13 +104,15 @@ pub(crate) fn handle_create_button_command(
                 window_id
             );
             unsafe {
-                windows::Win32::UI::WindowsAndMessaging::DestroyWindow(hwnd_button).ok();
+                // Safely ignore error if window is already gone.
+                DestroyWindow(hwnd_button).ok();
             }
             return Err(PlatformError::OperationFailed(format!(
-                "Button with ID {} already exists for window {:?}",
+                "Button with ID {} was created concurrently for window {:?}",
                 control_id, window_id
             )));
         }
+
         window_data.register_control_hwnd(control_id, hwnd_button);
         log::debug!(
             "ButtonHandler: Created button '{}' (ID {}) for window {:?} with HWND {:?}",
@@ -134,20 +121,8 @@ pub(crate) fn handle_create_button_command(
             window_id,
             hwnd_button
         );
-    } else {
-        log::warn!(
-            "ButtonHandler: WindowId {:?} disappeared before button insert. Destroying HWND.",
-            window_id
-        );
-        unsafe {
-            windows::Win32::UI::WindowsAndMessaging::DestroyWindow(hwnd_button).ok();
-        }
-        return Err(PlatformError::InvalidHandle(format!(
-            "WindowId {:?} not found after CreateButton",
-            window_id
-        )));
-    }
-    Ok(())
+        Ok(())
+    })
 }
 
 /*

--- a/src/platform_layer/controls/button_handler.rs
+++ b/src/platform_layer/controls/button_handler.rs
@@ -83,7 +83,7 @@ pub(crate) fn handle_create_button_command(
         }
 
         hwnd_parent_for_creation = window_data.get_hwnd();
-        h_instance = internal_state.h_instance;
+        h_instance = internal_state.h_instance();
     }
 
     let hwnd_button = unsafe {

--- a/src/platform_layer/controls/input_handler.rs
+++ b/src/platform_layer/controls/input_handler.rs
@@ -4,6 +4,7 @@
  * executor can update colors without direct Win32 calls.
  */
 
+use crate::platform_layer::PlatformResult;
 use crate::platform_layer::app::Win32ApiInternalState;
 use crate::platform_layer::types::WindowId;
 use std::sync::Arc;
@@ -19,25 +20,43 @@ pub(crate) struct InputColorState {
     pub brush: HBRUSH,
 }
 
-
+/*
+ * Handles the WM_CTLCOLOREDIT message for input controls.
+ * This function is called when an EDIT control is about to be drawn. It uses
+ * the with_window_data_read helper to safely look up if a custom background
+ * color has been set for the specific control. If so, it sets the background
+ * color and returns the corresponding brush handle.
+ */
 pub(crate) fn handle_wm_ctlcoloredit(
     internal_state: &Arc<Win32ApiInternalState>,
     window_id: WindowId,
     hdc_edit: windows::Win32::Graphics::Gdi::HDC,
     hwnd_edit: HWND,
 ) -> Option<LRESULT> {
-    let windows_map_guard = internal_state.active_windows().read().ok()?;
-    let window_data = windows_map_guard.get(&window_id)?;
-    let control_id = unsafe { GetDlgCtrlID(hwnd_edit) };
-    if control_id == 0 {
-        return None;
-    }
-    if let Some(state) = window_data.get_input_background_color(control_id) {
-        unsafe {
-            SetBkColor(hdc_edit, state.color);
-        }
-        return Some(LRESULT(state.brush.0 as isize));
-    }
-    None
-}
+    let result: PlatformResult<Option<LRESULT>> =
+        internal_state.with_window_data_read(window_id, |window_data| {
+            let control_id = unsafe { GetDlgCtrlID(hwnd_edit) };
+            if control_id == 0 {
+                // Not a control with an ID, or an error occurred. Let the system handle it.
+                return Ok(None);
+            }
 
+            if let Some(state) = window_data.get_input_background_color(control_id) {
+                unsafe {
+                    SetBkColor(hdc_edit, state.color);
+                }
+                // Return the brush handle for the system to use.
+                return Ok(Some(LRESULT(state.brush.0 as isize)));
+            }
+
+            // We found the window, but this specific control doesn't have a custom color.
+            Ok(None)
+        });
+    // Convert the PlatformResult<Option<LRESULT>> to Option<LRESULT>.
+    // - Ok(Some(lresult)) becomes Some(lresult).
+    // - Ok(None) becomes None.
+    // - Err(_) becomes None.
+    // This correctly mirrors the original function's behavior where any failure to
+    // find the window data resulted in default processing (returning None).
+    result.ok().flatten()
+}

--- a/src/platform_layer/controls/input_handler.rs
+++ b/src/platform_layer/controls/input_handler.rs
@@ -26,7 +26,7 @@ pub(crate) fn handle_wm_ctlcoloredit(
     hdc_edit: windows::Win32::Graphics::Gdi::HDC,
     hwnd_edit: HWND,
 ) -> Option<LRESULT> {
-    let windows_map_guard = internal_state.active_windows.read().ok()?;
+    let windows_map_guard = internal_state.active_windows().read().ok()?;
     let window_data = windows_map_guard.get(&window_id)?;
     let control_id = unsafe { GetDlgCtrlID(hwnd_edit) };
     if control_id == 0 {

--- a/src/platform_layer/controls/label_handler.rs
+++ b/src/platform_layer/controls/label_handler.rs
@@ -64,7 +64,7 @@ pub(crate) fn handle_create_label_command(
         class,
     );
 
-    let mut windows_map_guard = internal_state.active_windows.write().map_err(|e| {
+    let mut windows_map_guard = internal_state.active_windows().write().map_err(|e| {
         log::error!(
             "LabelHandler: Failed to lock windows map for CreateLabel: {:?}",
             e
@@ -196,7 +196,7 @@ pub(crate) fn handle_update_label_text_command(
 
     // Scope for the write lock on window_map to update label_severities
     {
-        let mut windows_map_guard = internal_state.active_windows.write().map_err(|e| {
+        let mut windows_map_guard = internal_state.active_windows().write().map_err(|e| {
             log::error!(
                 "LabelHandler: Failed to lock windows map for UpdateLabelText: {:?}",
                 e
@@ -294,10 +294,10 @@ pub(crate) fn handle_wm_ctlcolorstatic(
         hwnd_static_ctrl
     );
 
-    // No need to lock internal_state.active_windows for read here if we get all necessary info from window_data first.
+    // No need to lock internal_state.active_windows() for read here if we get all necessary info from window_data first.
     // However, we need to access window_data.label_severities.
 
-    let windows_map_guard = internal_state.active_windows.read().ok()?;
+    let windows_map_guard = internal_state.active_windows().read().ok()?;
     let window_data = windows_map_guard.get(&window_id)?;
 
     // Get the control ID from the HWND of the static control.

--- a/src/platform_layer/controls/label_handler.rs
+++ b/src/platform_layer/controls/label_handler.rs
@@ -33,19 +33,7 @@ use windows::{
  * Handles the creation of a native label (STATIC) control.
  * This function takes the necessary parameters to create a label, including its parent,
  * logical ID, initial text, and class. It registers the new label's HWND with the
- * NativeWindowData and sets its initial severity.
- *
- * Parameters:
- * - internal_state: Shared state of the Win32 platform layer.
- * - window_id: The logical ID of the window where the label will be created.
- * - parent_panel_id: The logical ID of the panel that will host this label.
- * - label_id: The logical ID to assign to this new label.
- * - initial_text: The text to display on the label initially.
- * - class: The class of the label, used for potential specific styling.
- *
- * Returns:
- * - Ok(()) if creation is successful.
- * - PlatformError if creation fails (e.g., parent not found, ID conflict).
+ * NativeWindowData and sets its initial severity, all within a single write transaction.
  */
 pub(crate) fn handle_create_label_command(
     internal_state: &Arc<Win32ApiInternalState>,
@@ -64,118 +52,92 @@ pub(crate) fn handle_create_label_command(
         class,
     );
 
-    let mut windows_map_guard = internal_state.active_windows().write().map_err(|e| {
-        log::error!(
-            "LabelHandler: Failed to lock windows map for CreateLabel: {:?}",
-            e
-        );
-        PlatformError::OperationFailed("Failed to lock windows map for CreateLabel".into())
-    })?;
-
-    let window_data = windows_map_guard.get_mut(&window_id).ok_or_else(|| {
-        log::warn!(
-            "LabelHandler: WindowId {:?} not found for CreateLabel.",
-            window_id
-        );
-        PlatformError::InvalidHandle(format!(
-            "WindowId {:?} not found for CreateLabel",
-            window_id
-        ))
-    })?;
-
-    if window_data.has_control(label_id) {
-        log::warn!(
-            "LabelHandler: Label with logical ID {} already exists for window {:?}.",
-            label_id,
-            window_id
-        );
-        return Err(PlatformError::OperationFailed(format!(
-            "Label with logical ID {} already exists for window {:?}",
-            label_id, window_id
-        )));
-    }
-
-    let hwnd_parent_panel = window_data
-        .get_control_hwnd(parent_panel_id)
-        .ok_or_else(|| {
+    internal_state.with_window_data_write(window_id, |window_data| {
+        if window_data.has_control(label_id) {
             log::warn!(
-                "LabelHandler: Parent panel with logical ID {} not found for CreateLabel in WinID {:?}.",
-                parent_panel_id, window_id
+                "LabelHandler: Label with logical ID {} already exists for window {:?}.",
+                label_id,
+                window_id
             );
-            PlatformError::InvalidHandle(format!(
-                "Parent panel with logical ID {} not found for CreateLabel in WinID {:?}",
-                parent_panel_id, window_id
-            ))
-        })?;
+            return Err(PlatformError::OperationFailed(format!(
+                "Label with logical ID {} already exists for window {:?}",
+                label_id, window_id
+            )));
+        }
 
-    let hwnd_label = unsafe {
-        CreateWindowExW(
-            WINDOW_EX_STYLE(0),
-            WC_STATIC, // Use constant for "STATIC"
-            &HSTRING::from(initial_text.as_str()),
-            WS_CHILD | WS_VISIBLE | SS_LEFT, // Basic label styles
-            0,
-            0,
-            10,
-            10, // Dummy position/size, layout rules will adjust
-            Some(hwnd_parent_panel),
-            Some(windows::Win32::UI::WindowsAndMessaging::HMENU(
-                label_id as *mut _,
-            )), // Use logical ID for the HMENU
-            Some(internal_state.h_instance()),
-            None,
-        )?
-    };
-
-    // Apply custom font if this is a status bar label and font exists
-    if class == LabelClass::StatusBar {
-        if let Some(h_font) = window_data.get_status_bar_font() {
-            if !h_font.is_invalid() {
-                unsafe {
-                    SendMessageW(
-                        hwnd_label,
-                        WM_SETFONT,
-                        Some(WPARAM(h_font.0 as usize)),
-                        Some(LPARAM(1)),
-                    )
-                }; // LPARAM(1) to redraw
-                log::debug!(
-                    "LabelHandler: Applied status bar font to label ID {}",
-                    label_id
+        let hwnd_parent_panel = window_data
+            .get_control_hwnd(parent_panel_id)
+            .ok_or_else(|| {
+                log::warn!(
+                    "LabelHandler: Parent panel with logical ID {} not found for CreateLabel in WinID {:?}.",
+                    parent_panel_id, window_id
                 );
+                PlatformError::InvalidHandle(format!(
+                    "Parent panel with logical ID {} not found for CreateLabel in WinID {:?}",
+                    parent_panel_id, window_id
+                ))
+            })?;
+
+        let h_instance = internal_state.h_instance();
+        let hwnd_label = unsafe {
+            CreateWindowExW(
+                WINDOW_EX_STYLE(0),
+                WC_STATIC, // Use constant for "STATIC"
+                &HSTRING::from(initial_text.as_str()),
+                WS_CHILD | WS_VISIBLE | SS_LEFT, // Basic label styles
+                0,
+                0,
+                10,
+                10, // Dummy position/size, layout rules will adjust
+                Some(hwnd_parent_panel),
+                Some(windows::Win32::UI::WindowsAndMessaging::HMENU(
+                    label_id as *mut _,
+                )), // Use logical ID for the HMENU
+                Some(h_instance),
+                None,
+            )?
+        };
+
+        // Apply custom font if this is a status bar label and font exists
+        if class == LabelClass::StatusBar {
+            if let Some(h_font) = window_data.get_status_bar_font() {
+                if !h_font.is_invalid() {
+                    unsafe {
+                        SendMessageW(
+                            hwnd_label,
+                            WM_SETFONT,
+                            Some(WPARAM(h_font.0 as usize)),
+                            Some(LPARAM(1)),
+                        )
+                    }; // LPARAM(1) to redraw
+                    log::debug!(
+                        "LabelHandler: Applied status bar font to label ID {}",
+                        label_id
+                    );
+                }
             }
         }
-    }
 
-    window_data.register_control_hwnd(label_id, hwnd_label);
-    window_data.set_label_severity(label_id, MessageSeverity::Information); // Default to Information
-    log::debug!(
-        "LabelHandler: Created label '{}' (LogicalID {}) for WinID {:?} with HWND {:?}",
-        initial_text,
-        label_id,
-        window_id,
-        hwnd_label
-    );
-    Ok(())
+        window_data.register_control_hwnd(label_id, hwnd_label);
+        window_data.set_label_severity(label_id, MessageSeverity::Information); // Default to Information
+        log::debug!(
+            "LabelHandler: Created label '{}' (LogicalID {}) for WinID {:?} with HWND {:?}",
+            initial_text,
+            label_id,
+            window_id,
+            hwnd_label
+        );
+        Ok(())
+    })
 }
 
 /*
  * Handles the update of a label's text and its associated severity.
- * This function retrieves the label's HWND using its logical ID and then
- * updates its text content and stores the new severity in NativeWindowData.
- * It also invalidates the label to trigger a repaint, allowing WM_CTLCOLORSTATIC
- * to apply any severity-based coloring.
- *
- * Parameters:
- * - internal_state: Shared state of the Win32 platform layer.
- * - window_id: The logical ID of the window containing the label.
- * - label_id: The logical ID of the label to update.
- * - text: The new text to display on the label.
- * - severity: The new message severity associated with the text.
- *
- * Returns:
- * - Ok(()) if the update is successful.
- * - PlatformError if the update fails (e.g., label not found).
+ * This function is carefully structured to avoid deadlocks. It first acquires a
+ * write lock to update the internal severity state and retrieve the label's HWND.
+ * It then RELEASES the lock before making any Win32 API calls that could
+ * synchronously dispatch messages (like SetWindowTextW), preventing a re-entrant
+ * lock on the same thread.
  */
 pub(crate) fn handle_update_label_text_command(
     internal_state: &Arc<Win32ApiInternalState>,
@@ -192,75 +154,44 @@ pub(crate) fn handle_update_label_text_command(
         severity
     );
 
-    let hwnd_label_for_api_call: Option<HWND>;
+    let hwnd_label =
+        internal_state.with_window_data_write(window_id, |window_data| {
+            let hwnd = window_data.get_control_hwnd(label_id).ok_or_else(|| {
+                log::warn!(
+                    "LabelHandler: Label with logical ID {} not found for UpdateLabelText in WinID {:?}.",
+                    label_id,
+                    window_id
+                );
+                PlatformError::InvalidHandle(format!(
+                    "Label with logical ID {} not found for UpdateLabelText in WinID {:?}",
+                    label_id, window_id
+                ))
+            })?;
 
-    // Scope for the write lock on window_map to update label_severities
-    {
-        let mut windows_map_guard = internal_state.active_windows().write().map_err(|e| {
+            // Update the severity state.
+            window_data.set_label_severity(label_id, severity);
+
+            // Return the HWND for use outside the lock.
+            Ok(hwnd)
+        })?;
+
+    unsafe {
+        if SetWindowTextW(hwnd_label, &HSTRING::from(text.as_str())).is_err() {
+            let last_error = GetLastError();
             log::error!(
-                "LabelHandler: Failed to lock windows map for UpdateLabelText: {:?}",
-                e
-            );
-            PlatformError::OperationFailed("Failed to lock windows map for UpdateLabelText".into())
-        })?;
-
-        let window_data = windows_map_guard.get_mut(&window_id).ok_or_else(|| {
-            log::warn!(
-                "LabelHandler: WindowId {:?} not found for UpdateLabelText.",
-                window_id
-            );
-            PlatformError::InvalidHandle(format!(
-                "WindowId {:?} not found for UpdateLabelText",
-                window_id
-            ))
-        })?;
-
-        hwnd_label_for_api_call = window_data.get_control_hwnd(label_id);
-        if hwnd_label_for_api_call.is_none() {
-            log::warn!(
-                "LabelHandler: Label with logical ID {} not found for UpdateLabelText in WinID {:?}.",
+                "LabelHandler: SetWindowTextW for label ID {} failed: {:?}",
                 label_id,
-                window_id
+                last_error
             );
-            return Err(PlatformError::InvalidHandle(format!(
-                "Label with logical ID {} not found for UpdateLabelText in WinID {:?}",
-                label_id, window_id
+            return Err(PlatformError::OperationFailed(format!(
+                "SetWindowTextW for label ID {} failed: {:?}",
+                label_id, last_error
             )));
         }
-        window_data.set_label_severity(label_id, severity);
-    } // Write lock released
-
-    // Now make WinAPI calls without holding the lock
-    if let Some(hwnd_label) = hwnd_label_for_api_call {
-        unsafe {
-            if SetWindowTextW(hwnd_label, &HSTRING::from(text)).is_err() {
-                let last_error = GetLastError();
-                log::error!(
-                    "LabelHandler: SetWindowTextW for label ID {} failed: {:?}",
-                    label_id,
-                    last_error
-                );
-                return Err(PlatformError::OperationFailed(format!(
-                    "SetWindowTextW for label ID {} failed: {:?}",
-                    label_id, last_error
-                )));
-            }
-            // Trigger repaint for WM_CTLCOLORSTATIC to apply new severity color
-            _ = InvalidateRect(Some(hwnd_label), None, true);
-        }
-        Ok(())
-    } else {
-        // This case should ideally be caught by the check above, but as a safeguard:
-        log::error!(
-            "LabelHandler: Label HWND for logical ID {} became invalid before API call in WinID {:?}.",
-            label_id,
-            window_id
-        );
-        Err(PlatformError::InvalidHandle(format!(
-            "Label HWND for logical ID {} became invalid before API call in WinID {:?}",
-            label_id, window_id
-        )))
+        // Trigger repaint for WM_CTLCOLORSTATIC to apply new severity color
+        _ = InvalidateRect(Some(hwnd_label), None, true);
     }
+    Ok(())
 }
 
 /*
@@ -268,18 +199,6 @@ pub(crate) fn handle_update_label_text_command(
  * This function is called when a label (STATIC control) is about to be drawn.
  * It determines the appropriate text color based on the label's stored severity
  * and sets the background to transparent.
- *
- * Parameters:
- * - internal_state: Shared state of the Win32 platform layer.
- * - window_id: The logical ID of the window containing the label.
- * - hdc_static_ctrl: The device context handle for the static control (from WPARAM).
- * - hwnd_static_ctrl: The window handle of the static control (from LPARAM).
- *
- * Returns:
- * - Some(LRESULT) containing the handle to the background brush if the message was
- *   handled for a known label.
- * - None if the control is not a known label or an error occurs, allowing default
- *   processing.
  */
 pub(crate) fn handle_wm_ctlcolorstatic(
     internal_state: &Arc<Win32ApiInternalState>,
@@ -294,50 +213,45 @@ pub(crate) fn handle_wm_ctlcolorstatic(
         hwnd_static_ctrl
     );
 
-    // No need to lock internal_state.active_windows() for read here if we get all necessary info from window_data first.
-    // However, we need to access window_data.label_severities.
-
-    let windows_map_guard = internal_state.active_windows().read().ok()?;
-    let window_data = windows_map_guard.get(&window_id)?;
-
-    // Get the control ID from the HWND of the static control.
-    // It's important that WM_CTLCOLORSTATIC's LPARAM is indeed the HWND of the control.
-    let control_id_of_static = unsafe { GetDlgCtrlID(hwnd_static_ctrl) };
-
-    if control_id_of_static == 0 {
-        // Not a dialog control, or an error occurred.
-        // This can happen for static text not created with a dialog ID.
-        log::trace!(
-            "LabelHandler: WM_CTLCOLORSTATIC for HWND {:?} which has no control ID or is not a dialog control. Defaulting.",
-            hwnd_static_ctrl
-        );
-        return None;
-    }
-
-    if let Some(severity) = window_data.get_label_severity(control_id_of_static) {
-        log::trace!(
-            "LabelHandler: Found severity {:?} for label ID {} (HWND {:?})",
-            severity,
-            control_id_of_static,
-            hwnd_static_ctrl
-        );
-        unsafe {
-            let color = match severity {
-                MessageSeverity::Error => windows::Win32::Foundation::COLORREF(0x000000FF), // Red
-                MessageSeverity::Warning => windows::Win32::Foundation::COLORREF(0x0000A5FF), // Orange-ish
-                _ => windows::Win32::Foundation::COLORREF(GetSysColor(COLOR_WINDOWTEXT)),
-            };
-            SetTextColor(hdc_static_ctrl, color);
-            SetBkMode(hdc_static_ctrl, TRANSPARENT);
-            // Return the brush for the parent window's background
-            return Some(LRESULT(GetSysColorBrush(COLOR_WINDOW).0 as isize));
+    let result = internal_state.with_window_data_read(window_id, |window_data| {
+        let control_id_of_static = unsafe { GetDlgCtrlID(hwnd_static_ctrl) };
+        if control_id_of_static == 0 {
+            log::trace!(
+                "LabelHandler: WM_CTLCOLORSTATIC for HWND {:?} which has no control ID. Defaulting.",
+                hwnd_static_ctrl
+            );
+            return Ok(None);
         }
-    } else {
+
+        if let Some(severity) = window_data.get_label_severity(control_id_of_static) {
+            log::trace!(
+                "LabelHandler: Found severity {:?} for label ID {} (HWND {:?})",
+                severity,
+                control_id_of_static,
+                hwnd_static_ctrl
+            );
+            unsafe {
+                let color = match severity {
+                    MessageSeverity::Error => windows::Win32::Foundation::COLORREF(0x000000FF), // Red
+                    MessageSeverity::Warning => windows::Win32::Foundation::COLORREF(0x0000A5FF), // Orange-ish
+                    _ => windows::Win32::Foundation::COLORREF(GetSysColor(COLOR_WINDOWTEXT)),
+                };
+                SetTextColor(hdc_static_ctrl, color);
+                SetBkMode(hdc_static_ctrl, TRANSPARENT);
+                // Return the brush for the parent window's background
+                let brush_result = LRESULT(GetSysColorBrush(COLOR_WINDOW).0 as isize);
+                return Ok(Some(brush_result));
+            }
+        }
+
         log::trace!(
             "LabelHandler: No severity found for label ID {} (HWND {:?}). Defaulting.",
             control_id_of_static,
             hwnd_static_ctrl
         );
-    }
-    None // Default processing
+        Ok(None) // Default processing
+    });
+
+    // Convert PlatformResult<Option<LRESULT>> to Option<LRESULT>
+    result.ok().flatten()
 }

--- a/src/platform_layer/controls/label_handler.rs
+++ b/src/platform_layer/controls/label_handler.rs
@@ -122,7 +122,7 @@ pub(crate) fn handle_create_label_command(
             Some(windows::Win32::UI::WindowsAndMessaging::HMENU(
                 label_id as *mut _,
             )), // Use logical ID for the HMENU
-            Some(internal_state.h_instance),
+            Some(internal_state.h_instance()),
             None,
         )?
     };

--- a/src/platform_layer/controls/treeview_handler.rs
+++ b/src/platform_layer/controls/treeview_handler.rs
@@ -17,7 +17,7 @@ use crate::platform_layer::types::{
 
 use windows::{
     Win32::{
-        Foundation::{GetLastError, HINSTANCE, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM},
+        Foundation::{GetLastError, HWND, LPARAM, LRESULT, POINT, RECT, WPARAM},
         Graphics::Gdi::{
             CreateSolidBrush, DeleteObject, Ellipse, HGDIOBJ, InvalidateRect, ScreenToClient,
             SelectObject,
@@ -25,11 +25,11 @@ use windows::{
         UI::Controls::{
             CDDS_ITEMPOSTPAINT, CDDS_ITEMPREPAINT, CDDS_PREPAINT, CDRF_DODEFAULT,
             CDRF_NOTIFYITEMDRAW, CDRF_NOTIFYPOSTPAINT, HTREEITEM, NMHDR, NMTVCUSTOMDRAW,
-            TVHITTESTINFO, TVHITTESTINFO_FLAGS, TVHT_ONITEMSTATEICON, TVI_LAST, TVIF_CHILDREN,
-            TVIF_PARAM, TVIF_STATE, TVIF_TEXT, TVINSERTSTRUCTW, TVINSERTSTRUCTW_0,
-            TVIS_STATEIMAGEMASK, TVITEMEXW, TVITEMEXW_CHILDREN, TVM_DELETEITEM, TVM_GETITEMRECT,
-            TVM_GETITEMW, TVM_HITTEST, TVM_INSERTITEMW, TVM_SETITEMW, TVS_CHECKBOXES,
-            TVS_HASBUTTONS, TVS_HASLINES, TVS_LINESATROOT, TVS_SHOWSELALWAYS, WC_TREEVIEWW,
+            TVHITTESTINFO, TVHT_ONITEMSTATEICON, TVI_LAST, TVIF_CHILDREN, TVIF_PARAM, TVIF_STATE,
+            TVIF_TEXT, TVINSERTSTRUCTW, TVINSERTSTRUCTW_0, TVIS_STATEIMAGEMASK, TVITEMEXW,
+            TVITEMEXW_CHILDREN, TVM_DELETEITEM, TVM_GETITEMRECT, TVM_GETITEMW, TVM_HITTEST,
+            TVM_INSERTITEMW, TVM_SETITEMW, TVS_CHECKBOXES, TVS_HASBUTTONS, TVS_HASLINES,
+            TVS_LINESATROOT, TVS_SHOWSELALWAYS, WC_TREEVIEWW,
         },
         UI::WindowsAndMessaging::*,
     },
@@ -181,9 +181,9 @@ impl TreeViewInternalState {
 
 /*
  * Handles the creation of a native TreeView control.
- * This function takes the window ID and a logical control ID, creates the
- * TreeView using CreateWindowExW, and initializes its internal state within
- * the corresponding NativeWindowData.
+ * This function uses a read-create-write pattern to minimize lock contention.
+ * It first checks for conflicts using a read lock, then creates the native
+ * control, and finally uses a write lock to register the new control and its state.
  */
 pub(crate) fn handle_create_treeview_command(
     internal_state: &Arc<Win32ApiInternalState>,
@@ -196,56 +196,27 @@ pub(crate) fn handle_create_treeview_command(
         control_id
     );
 
-    let hwnd_parent_for_creation: HWND;
-    let h_instance_for_creation: HINSTANCE;
-
-    // Phase 1: Acquire read lock, perform checks, and get necessary data for CreateWindowExW
-    {
-        let windows_map_guard = internal_state.active_windows().read().map_err(|e|{
-            log::error!("TreeViewHandler: Failed to lock windows map (read) for TreeView creation pre-check: {:?}", e);
-            PlatformError::OperationFailed("Failed to lock windows map (read) for TreeView creation pre-check".into())
+    // Phase 1: Read-only pre-checks.
+    let hwnd_parent_for_creation =
+        internal_state.with_window_data_read(window_id, |window_data| {
+            if window_data.has_control(control_id) || window_data.has_treeview_state() {
+                return Err(PlatformError::ControlCreationFailed(format!(
+                    "TreeView with ID {} or existing state already present for window {:?}",
+                    control_id, window_id
+                )));
+            }
+            let hwnd = window_data.get_hwnd();
+            if hwnd.is_invalid() {
+                return Err(PlatformError::InvalidHandle(format!(
+                    "Parent HWND for CreateTreeView is invalid (WinID: {:?})",
+                    window_id
+                )));
+            }
+            Ok(hwnd)
         })?;
 
-        let window_data = windows_map_guard.get(&window_id).ok_or_else(|| {
-            log::warn!(
-                "TreeViewHandler: WindowId {:?} not found for CreateTreeView pre-check.",
-                window_id
-            );
-            PlatformError::InvalidHandle(format!(
-                "WindowId {:?} not found for CreateTreeView pre-check",
-                window_id
-            ))
-        })?;
-
-        if window_data.has_control(control_id)
-            || window_data.has_treeview_state()
-        {
-            log::warn!(
-                "TreeViewHandler: TreeView with ID {} or existing TreeView state already present for window {:?}.",
-                control_id,
-                window_id
-            );
-            return Err(PlatformError::ControlCreationFailed(format!(
-                "TreeView with ID {} or existing TreeView state already present for window {:?}",
-                control_id, window_id
-            )));
-        }
-        hwnd_parent_for_creation = window_data.get_hwnd();
-        h_instance_for_creation = internal_state.h_instance();
-
-        if hwnd_parent_for_creation.is_invalid() {
-            log::warn!(
-                "TreeViewHandler: Parent HWND for CreateTreeView is invalid (WinID: {:?})",
-                window_id
-            );
-            return Err(PlatformError::InvalidHandle(format!(
-                "Parent HWND for CreateTreeView is invalid (WinID: {:?})",
-                window_id
-            )));
-        }
-    } // Read lock released
-
-    // Phase 2: Create the window without holding the lock
+    // Phase 2: Create the window without holding a lock.
+    let h_instance_for_creation = internal_state.h_instance();
     let tvs_style = WINDOW_STYLE(
         TVS_HASLINES | TVS_LINESATROOT | TVS_HASBUTTONS | TVS_SHOWSELALWAYS | TVS_CHECKBOXES,
     );
@@ -267,45 +238,17 @@ pub(crate) fn handle_create_treeview_command(
         )?
     };
 
-    // Phase 3: Re-acquire write lock to update NativeWindowData
-    {
-        let mut windows_map_guard = internal_state.active_windows().write().map_err(|e| {
-            log::error!(
-                "TreeViewHandler: Failed to re-acquire write lock for TreeView creation post-update: {:?}",
-                e
-            );
-            unsafe { DestroyWindow(hwnd_tv).ok(); } // Try to clean up orphaned window
-            PlatformError::OperationFailed(
-                "Failed to re-acquire write lock for TreeView creation post-update".into(),
-            )
-        })?;
-
-        let window_data = windows_map_guard.get_mut(&window_id).ok_or_else(|| {
+    // Phase 3: Acquire write lock to update NativeWindowData.
+    internal_state.with_window_data_write(window_id, |window_data| {
+        // Re-check for race conditions.
+        if window_data.has_control(control_id) || window_data.has_treeview_state() {
             log::warn!(
-                "TreeViewHandler: WindowId {:?} no longer exists for CreateTreeView post-update. Destroying orphaned control.",
-                window_id
+                "TreeViewHandler: TreeView (ID {}) created concurrently. Destroying new one.",
+                control_id
             );
-            unsafe { DestroyWindow(hwnd_tv).ok(); }
-            PlatformError::InvalidHandle(format!(
-                "WindowId {:?} no longer exists for CreateTreeView post-update",
-                window_id
-            ))
-        })?;
-
-        // Check again in case the window was destroyed or control created by another thread
-        if window_data.has_control(control_id)
-            || window_data.has_treeview_state()
-        {
-            log::warn!(
-                "TreeViewHandler: TreeView (ID {}) or state for window {:?} was created concurrently or window was altered. Destroying newly created one.",
-                control_id,
-                window_id
-            );
-            unsafe {
-                DestroyWindow(hwnd_tv).ok();
-            }
+            unsafe { DestroyWindow(hwnd_tv).ok() };
             return Err(PlatformError::ControlCreationFailed(format!(
-                "TreeView with ID {} or state was concurrently created for window {:?}",
+                "TreeView with ID {} was concurrently created for window {:?}",
                 control_id, window_id
             )));
         }
@@ -318,16 +261,16 @@ pub(crate) fn handle_create_treeview_command(
             window_id,
             hwnd_tv
         );
-    } // Write lock is released
-
-    Ok(())
+        Ok(())
+    })
 }
 
 /*
  * Populates a TreeView control with a given set of item descriptors.
  * This function clears any existing items in the TreeView and then recursively
- * adds the new items. It manages the internal `TreeViewInternalState` for
- * mapping application item IDs to native handles.
+ * adds the new items. It uses the specialized `with_treeview_state_mut` helper
+ * to ensure the main window map is not locked during the potentially lengthy
+ * population process.
  */
 pub(crate) fn populate_treeview(
     internal_state: &Arc<Win32ApiInternalState>,
@@ -341,139 +284,23 @@ pub(crate) fn populate_treeview(
         control_id
     );
 
-    let hwnd_treeview: HWND;
-    let mut taken_tv_state: Option<TreeViewInternalState>;
-
-    // Phase 1: Lock, get HWND, take tv_state
-    {
-        let mut windows_map_guard = internal_state.active_windows().write().map_err(|e| {
-            log::error!(
-                "TreeViewHandler: Failed to lock windows map for populate_treeview (phase 1): {:?}",
-                e
-            );
-            PlatformError::OperationFailed(
-                "Failed to lock windows map for populate_treeview (phase 1)".into(),
-            )
-        })?;
-
-        let window_data = windows_map_guard.get_mut(&window_id).ok_or_else(|| {
-            log::warn!(
-                "TreeViewHandler: WindowId {:?} not found for populate_treeview.",
-                window_id
-            );
-            PlatformError::InvalidHandle(format!(
-                "WindowId {:?} not found for populate_treeview",
-                window_id
-            ))
-        })?;
-
-        hwnd_treeview = window_data
-            .get_control_hwnd(control_id)
-            .ok_or_else(|| {
-                log::warn!("TreeViewHandler: TreeView HWND not found for ControlID {} in WinID {:?} before populating.", control_id, window_id);
-                PlatformError::InvalidHandle(format!(
-                    "TreeView HWND not found for ControlID {} in WinID {:?} before populating.",
-                    control_id, window_id
-                ))
-            })?;
-
-        if hwnd_treeview.is_invalid() {
-            log::warn!(
-                "TreeViewHandler: TreeView HWND is invalid for ControlID {} in WinID {:?} before populating.",
-                control_id,
-                window_id
-            );
-            return Err(PlatformError::InvalidHandle(format!(
-                "TreeView HWND is invalid for ControlID {} in WinID {:?} before populating.",
-                control_id, window_id
-            )));
-        }
-        taken_tv_state = window_data.take_treeview_state();
-        if taken_tv_state.is_none() {
-            log::warn!(
-                "TreeViewHandler: TreeView state was None for WinID {:?}/ControlID {}, creating new for population.",
-                window_id,
-                control_id
-            );
-            taken_tv_state = Some(TreeViewInternalState::new());
-        }
-    } // Write lock on window_map released
-
-    // Phase 2: Perform operations on taken_tv_state and HWND, NO window_map lock held
-    if let Some(mut tv_state_actual) = taken_tv_state {
-        tv_state_actual.clear_items_impl(hwnd_treeview);
+    internal_state.with_treeview_state_mut(window_id, control_id, |hwnd_treeview, tv_state| {
         log::debug!(
-            "TreeViewHandler: Cleared existing items from TreeView (HWND {:?}) for WinID {:?}/ControlID {}.",
-            hwnd_treeview,
-            window_id,
-            control_id
+            "TreeViewHandler: Populating TreeView (HWND {:?}). Clearing existing items.",
+            hwnd_treeview
         );
+        tv_state.clear_items_impl(hwnd_treeview);
 
         for item_desc in items {
-            if let Err(e) =
-                tv_state_actual.add_item_recursive_impl(hwnd_treeview, HTREEITEM(0), &item_desc)
-            {
-                // Attempt to put state back on error
-                let mut windows_map_guard = internal_state.active_windows().write().map_err(|re_lock_err| {
-                    log::error!("TreeViewHandler: Failed to re-lock windows map for populate_treeview (error recovery): {:?}", re_lock_err);
-                    // Original error `e` is more important, but log this too.
-                    e.clone() // Return original error
-                })?;
-                if let Some(window_data_err_case) = windows_map_guard.get_mut(&window_id) {
-                    window_data_err_case.set_treeview_state(Some(tv_state_actual));
-                } else {
-                    log::error!(
-                        "TreeViewHandler: Failed to put back tv_state for {:?} after error: window not found",
-                        window_id
-                    );
-                }
-                return Err(e);
-            }
+            tv_state.add_item_recursive_impl(hwnd_treeview, HTREEITEM(0), &item_desc)?;
         }
+
         log::debug!(
-            "TreeViewHandler: Finished populating TreeView (HWND {:?}) for WinID {:?}/ControlID {}.",
-            hwnd_treeview,
-            window_id,
-            control_id
+            "TreeViewHandler: Finished populating TreeView (HWND {:?}).",
+            hwnd_treeview
         );
-        taken_tv_state = Some(tv_state_actual); // tv_state_actual is moved back
-    } else {
-        // This should not happen if the logic in Phase 1 is correct
-        log::error!(
-            "TreeViewHandler: TreeView state was unexpectedly None after take in populate_treeview."
-        );
-        return Err(PlatformError::OperationFailed(
-            "TreeView state was unexpectedly None after take".to_string(),
-        ));
-    }
-
-    // Phase 3: Lock, put tv_state back
-    {
-        let mut windows_map_guard = internal_state.active_windows().write().map_err(|e| {
-            log::error!(
-                "TreeViewHandler: Failed to lock windows map for populate_treeview (phase 3): {:?}",
-                e
-            );
-            PlatformError::OperationFailed(
-                "Failed to lock windows map for populate_treeview (phase 3)".into(),
-            )
-        })?;
-        if let Some(window_data) = windows_map_guard.get_mut(&window_id) {
-            window_data.set_treeview_state(taken_tv_state);
-        } else {
-            log::error!(
-                "TreeViewHandler: WindowId {:?} disappeared while TreeView (ControlID {}) was being populated.",
-                window_id,
-                control_id
-            );
-            return Err(PlatformError::InvalidHandle(format!(
-                "WindowId {:?} not found when trying to restore TreeView state for ControlID {}.",
-                window_id, control_id
-            )));
-        }
-    }
-
-    Ok(())
+        Ok(())
+    })
 }
 
 /*
@@ -495,67 +322,36 @@ pub(crate) fn update_treeview_item_visual_state(
         item_id
     );
 
-    let hwnd_treeview: HWND;
-    let h_item_native: HTREEITEM;
-
-    {
-        // Read lock scope
-        let windows_guard = internal_state.active_windows().read().map_err(|e|{
-            log::error!("TreeViewHandler: Failed to acquire read lock for windows map (update visual): {:?}",e);
-            PlatformError::OperationFailed("Failed to acquire read lock for windows map (update visual)".into())
-        })?;
-
-        let window_data = windows_guard.get(&window_id).ok_or_else(|| {
-            log::warn!(
-                "TreeViewHandler: WindowId {:?} not found for UpdateVisualState.",
-                window_id
-            );
-            PlatformError::InvalidHandle(format!(
-                "WindowId {:?} not found for UpdateVisualState",
-                window_id
-            ))
-        })?;
-
-        hwnd_treeview = window_data
-            .get_control_hwnd(control_id)
-            .ok_or_else(|| {
-                log::warn!("TreeViewHandler: TreeView HWND not found for ControlID {} in WinID {:?} during UpdateVisualState.", control_id, window_id);
+    // Get all necessary handles and data within a single read lock.
+    let (hwnd_treeview, h_item_native) =
+        internal_state.with_window_data_read(window_id, |window_data| {
+            let hwnd = window_data.get_control_hwnd(control_id).ok_or_else(|| {
                 PlatformError::InvalidHandle(format!(
-                    "TreeView HWND not found for ControlID {} in WinID {:?} during UpdateVisualState.",
-                    control_id, window_id
+                    "TreeView HWND not found for ControlID {}",
+                    control_id
                 ))
             })?;
 
-        let tv_state = window_data.get_treeview_state().ok_or_else(|| {
-            log::warn!("TreeViewHandler: No TreeView state exists in window {:?} for UpdateVisualState (ControlID {})", window_id, control_id);
-            PlatformError::OperationFailed(format!(
-                "No TreeView state exists in window {:?} for UpdateVisualState (ControlID {})",
-                window_id, control_id
-            ))
-        })?;
-
-        h_item_native = tv_state
-            .item_id_to_htreeitem
-            .get(&item_id)
-            .copied()
-            .ok_or_else(|| {
-                 log::warn!("TreeViewHandler: TreeItemId {:?} not found in window {:?}/ControlID {} for UpdateVisualState", item_id, window_id, control_id);
-                PlatformError::InvalidHandle(format!(
-                    "TreeItemId {:?} not found in window {:?}/ControlID {} for UpdateVisualState",
-                    item_id, window_id, control_id
+            let tv_state = window_data.get_treeview_state().ok_or_else(|| {
+                PlatformError::OperationFailed(format!(
+                    "No TreeView state exists in window {:?}",
+                    window_id
                 ))
             })?;
-    } // Read lock released
+
+            let h_item = tv_state
+                .item_id_to_htreeitem
+                .get(&item_id)
+                .copied()
+                .ok_or_else(|| {
+                    PlatformError::InvalidHandle(format!("TreeItemId {:?} not found", item_id))
+                })?;
+
+            Ok((hwnd, h_item))
+        })?;
 
     if hwnd_treeview.is_invalid() {
-        log::warn!(
-            "TreeViewHandler: Invalid TreeView HWND for ControlID {} in visual update",
-            control_id
-        );
-        return Err(PlatformError::InvalidHandle(format!(
-            "Invalid TreeView HWND for ControlID {} in visual update",
-            control_id
-        )));
+        return Err(PlatformError::InvalidHandle("Invalid TreeView HWND".into()));
     }
 
     let image_index = match new_check_state {
@@ -581,17 +377,10 @@ pub(crate) fn update_treeview_item_visual_state(
     };
 
     if send_result.0 == 0 {
-        // TVM_SETITEMW returns 0 on failure
         let last_error = unsafe { GetLastError() };
-        log::error!(
-            "TreeViewHandler: TVM_SETITEMW failed for item {:?} in ControlID {}: {:?}",
-            item_id,
-            control_id,
-            last_error
-        );
         return Err(PlatformError::OperationFailed(format!(
-            "TVM_SETITEMW failed for item {:?} in ControlID {}: {:?}",
-            item_id, control_id, last_error
+            "TVM_SETITEMW failed for item {:?}: {:?}",
+            item_id, last_error
         )));
     }
     Ok(())
@@ -600,63 +389,36 @@ pub(crate) fn update_treeview_item_visual_state(
 /*
  * Handles the TVN_ITEMCHANGEDW notification for a TreeView.
  * This notification is sent for various item state changes, but this handler
- * currently only logs the event. More specific handling (e.g., for selection
- * changes if needed by app logic) could be added here.
+ * currently only logs the event.
  */
 pub(crate) fn handle_treeview_itemchanged_notification(
     internal_state: &Arc<Win32ApiInternalState>,
     window_id: WindowId,
-    lparam: LPARAM,
+    _lparam: LPARAM,
     control_id_from_notify: i32,
 ) -> Option<AppEvent> {
     log::trace!(
-        "TreeViewHandler: handle_treeview_itemchanged_notification received for WinID {:?}, ControlID {}, lparam {:?}",
+        "TreeViewHandler: TVN_ITEMCHANGEDW received for WinID {:?}, ControlID {}",
         window_id,
         control_id_from_notify,
-        lparam
     );
-
-    // Ensure TreeView state exists for this control_id
-    let windows_guard = match internal_state.active_windows().read() {
-        Ok(g) => g,
-        Err(e) => {
-            log::error!(
-                "TreeViewHandler: Failed to get read lock on active_windows in handle_treeview_itemchanged_notification: {:?}",
-                e
-            );
-            return None;
-        }
-    };
-    let window_data = match windows_guard.get(&window_id) {
-        Some(wd) => wd,
-        None => {
-            log::warn!(
-                "TreeViewHandler: WindowData not found for WinID {:?} in handle_treeview_itemchanged_notification",
-                window_id
-            );
-            return None;
-        }
-    };
-    if !window_data.has_treeview_state() {
-        log::warn!(
-            "TreeViewHandler: handle_treeview_itemchanged_notification: tv_state does not exist for WinID {:?}/ControlID {}.",
-            window_id,
-            control_id_from_notify
-        );
+    // Check if TreeView state exists for this window.
+    if let Ok(false) =
+        internal_state.with_window_data_read(window_id, |wd| Ok(wd.has_treeview_state()))
+    {
+        log::warn!("Received TVN_ITEMCHANGEDW for a window without treeview state.");
         return None;
     }
+
+    // `lparam` could be used here to get more details if needed.
     // let nmtv = unsafe { &*(lparam.0 as *const NMTREEVIEWW) };
-    // log::debug!("TVN_ITEMCHANGEDW: uOldState: {:#X}, uNewState: {:#X}, action: {:#X}, item id via param: {} for ControlID {}",
-    //    nmtv.itemOld.state, nmtv.itemNew.state, nmtv.action, nmtv.itemNew.lParam, control_id_from_notify);
     None // No AppEvent generated from this notification directly for now
 }
 
 /*
  * Executes the `RedrawTreeItem` command by invalidating the rectangle of a specific item.
  * This function retrieves the native `HTREEITEM` for the given `TreeItemId` and
- * uses `TVM_GETITEMRECT` to find its bounding box. It then calls `InvalidateRect`
- * to force a repaint of that item, which is crucial for updating custom-drawn
- * elements like the "New" item indicator.
+ * uses `TVM_GETITEMRECT` to find its bounding box, then forces a repaint.
  */
 pub(crate) fn handle_redraw_tree_item_command(
     internal_state: &Arc<Win32ApiInternalState>,
@@ -665,71 +427,43 @@ pub(crate) fn handle_redraw_tree_item_command(
     item_id: TreeItemId,
 ) -> PlatformResult<()> {
     log::debug!(
-        "TreeViewHandler: handle_redraw_tree_item_command for WinID {:?}, ControlID {}, ItemID {:?}",
+        "TreeViewHandler: handle_redraw_tree_item_command for WinID {:?}, ItemID {:?}",
         window_id,
-        control_id,
         item_id
     );
 
-    let hwnd_treeview: HWND;
-    let htreeitem: HTREEITEM;
-
-    {
-        // Read lock scope
-        let windows_guard = internal_state.active_windows().read().map_err(|e| {
-            log::error!("TreeViewHandler: Failed to acquire read lock on windows map for RedrawTreeItem: {:?}", e);
-            PlatformError::OperationFailed("Failed to lock active_windows map for RedrawTreeItem".into())
-        })?;
-
-        let window_data = windows_guard.get(&window_id).ok_or_else(|| {
-            log::warn!(
-                "TreeViewHandler: WindowId {:?} not found for RedrawTreeItem.",
-                window_id
-            );
-            PlatformError::InvalidHandle(format!(
-                "WindowId {:?} not found for RedrawTreeItem",
-                window_id
-            ))
-        })?;
-
-        hwnd_treeview = window_data
-            .get_control_hwnd(control_id)
-            .ok_or_else(|| {
-                log::warn!("TreeViewHandler: TreeView control (ID {}) not found for WinID {:?} during RedrawTreeItem.", control_id, window_id);
+    let (hwnd_treeview, htreeitem) =
+        internal_state.with_window_data_read(window_id, |window_data| {
+            let hwnd = window_data.get_control_hwnd(control_id).ok_or_else(|| {
                 PlatformError::InvalidHandle(format!(
-                    "TreeView control (ID {}) not found for WinID {:?} during RedrawTreeItem.",
-                    control_id, window_id
+                    "TreeView control (ID {}) not found",
+                    control_id
                 ))
             })?;
 
-        if hwnd_treeview.is_invalid() {
-            log::warn!(
-                "TreeViewHandler: TreeView HWND for ControlID {} is invalid for WinID {:?} during RedrawTreeItem.",
-                control_id,
-                window_id
-            );
-            return Err(PlatformError::InvalidHandle(format!(
-                "TreeView HWND for ControlID {} is invalid for WinID {:?} during RedrawTreeItem.",
-                control_id, window_id
-            )));
-        }
+            let tv_state = window_data.get_treeview_state().ok_or_else(|| {
+                PlatformError::OperationFailed(format!(
+                    "TreeView state not found for WinID {:?}",
+                    window_id
+                ))
+            })?;
 
-        let tv_state = window_data.get_treeview_state().ok_or_else(|| {
-            log::warn!("TreeViewHandler: TreeView state not found for WinID {:?} (ControlID {}) during RedrawTreeItem.", window_id, control_id);
-            PlatformError::OperationFailed(format!(
-                "TreeView state not found for WinID {:?} (ControlID {}) during RedrawTreeItem.",
-                window_id, control_id
-            ))
+            let h_item = tv_state
+                .item_id_to_htreeitem
+                .get(&item_id)
+                .copied()
+                .ok_or_else(|| {
+                    PlatformError::InvalidHandle(format!(
+                        "HTREEITEM not found for ItemID {:?}",
+                        item_id
+                    ))
+                })?;
+            Ok((hwnd, h_item))
         })?;
 
-        htreeitem = tv_state.item_id_to_htreeitem.get(&item_id).copied().ok_or_else(|| {
-            log::warn!("TreeViewHandler: HTREEITEM not found for ItemID {:?} (ControlID {}) during RedrawTreeItem. Cannot invalidate.", item_id, control_id);
-            PlatformError::InvalidHandle(format!(
-                "HTREEITEM not found for ItemID {:?} (ControlID {}) during RedrawTreeItem.",
-                item_id, control_id
-            ))
-        })?;
-    } // Read lock released
+    if hwnd_treeview.is_invalid() {
+        return Err(PlatformError::InvalidHandle("Invalid TreeView HWND".into()));
+    }
 
     let mut item_rect = RECT::default();
     unsafe {
@@ -740,37 +474,49 @@ pub(crate) fn handle_redraw_tree_item_command(
         SendMessageW(
             hwnd_treeview,
             TVM_GETITEMRECT,
-            Some(WPARAM(0)), // TRUE for text-only, FALSE for whole item
+            Some(WPARAM(0)), // FALSE for whole item
             Some(LPARAM(&mut item_rect as *mut _ as isize)),
         )
     };
 
     if get_rect_success.0 != 0 {
-        // Non-zero indicates success
         unsafe {
-            _ = InvalidateRect(Some(hwnd_treeview), Some(&item_rect), true); // TRUE for bErase
+            _ = InvalidateRect(Some(hwnd_treeview), Some(&item_rect), true);
         }
-        log::debug!(
-            "TreeViewHandler: Invalidated rect {:?} for item ID {:?} (HTREEITEM {:?}, ControlID {})",
-            item_rect,
-            item_id,
-            htreeitem,
-            control_id
-        );
     } else {
-        let last_error = unsafe { GetLastError() };
         log::warn!(
-            "TreeViewHandler: TVM_GETITEMRECT failed for item ID {:?} (HTREEITEM {:?}, ControlID {}) during RedrawTreeItem. Invalidating whole control. Error: {:?}",
+            "TVM_GETITEMRECT failed for item ID {:?}, invalidating whole control. Error: {:?}",
             item_id,
-            htreeitem,
-            control_id,
-            last_error
+            unsafe { GetLastError() }
         );
         unsafe {
-            _ = InvalidateRect(Some(hwnd_treeview), None, true); // Invalidate the whole TreeView
+            _ = InvalidateRect(Some(hwnd_treeview), None, true);
         }
     }
     Ok(())
+}
+
+fn get_treeview_hwnd(
+    internal_state: &Arc<Win32ApiInternalState>,
+    window_id: WindowId,
+    control_id: i32,
+) -> PlatformResult<HWND> {
+    internal_state.with_window_data_read(window_id, |window_data| {
+        let hwnd = window_data.get_control_hwnd(control_id).ok_or_else(|| {
+            PlatformError::InvalidHandle(format!(
+                "Control ID {} not found in WinID {:?}",
+                control_id, window_id
+            ))
+        })?;
+
+        if hwnd.is_invalid() {
+            return Err(PlatformError::InvalidHandle(format!(
+                "HWND for control ID {} is invalid",
+                control_id
+            )));
+        }
+        Ok(hwnd)
+    })
 }
 
 pub(crate) fn expand_visible_tree_items(
@@ -783,54 +529,7 @@ pub(crate) fn expand_visible_tree_items(
         window_id,
         control_id
     );
-
-    let hwnd_treeview = {
-        let windows_guard = internal_state.active_windows().read().map_err(|e| {
-            log::error!(
-                "TreeViewHandler: Failed to lock windows map (expand_visible_tree_items): {:?}",
-                e
-            );
-            PlatformError::OperationFailed(
-                "Failed to lock windows map for expand_visible_tree_items".into(),
-            )
-        })?;
-
-        let window_data = windows_guard.get(&window_id).ok_or_else(|| {
-            log::warn!(
-                "TreeViewHandler: WindowId {:?} not found for expand_visible_tree_items",
-                window_id
-            );
-            PlatformError::InvalidHandle(format!(
-                "WindowId {:?} not found for expand_visible_tree_items",
-                window_id
-            ))
-        })?;
-
-        let hwnd = window_data
-            .get_control_hwnd(control_id)
-            .ok_or_else(|| {
-                log::warn!(
-                    "TreeViewHandler: Control ID {} not found for expand_visible_tree_items in WinID {:?}",
-                    control_id,
-                    window_id
-                );
-                PlatformError::InvalidHandle(format!(
-                    "Control ID {} not found for expand_visible_tree_items in WinID {:?}",
-                    control_id, window_id
-                ))
-            })?;
-        hwnd
-    };
-
-    if hwnd_treeview.is_invalid() {
-        log::warn!(
-            "TreeViewHandler: HWND invalid for expand_visible_tree_items in ControlID {}",
-            control_id
-        );
-        return Err(PlatformError::InvalidHandle(
-            "Invalid TreeView HWND for expand_visible_tree_items".to_string(),
-        ));
-    }
+    let hwnd_treeview = get_treeview_hwnd(internal_state, window_id, control_id)?;
 
     use windows::Win32::UI::Controls::{
         TVE_EXPAND, TVGN_FIRSTVISIBLE, TVGN_NEXTVISIBLE, TVM_EXPAND, TVM_GETNEXTITEM,
@@ -874,52 +573,7 @@ pub(crate) fn expand_all_tree_items(
         window_id,
         control_id
     );
-
-    let hwnd_treeview = {
-        let windows_guard = internal_state.active_windows().read().map_err(|e| {
-            log::error!(
-                "TreeViewHandler: Failed to lock windows map (expand_all_tree_items): {:?}",
-                e
-            );
-            PlatformError::OperationFailed(
-                "Failed to lock windows map for expand_all_tree_items".into(),
-            )
-        })?;
-
-        let window_data = windows_guard.get(&window_id).ok_or_else(|| {
-            log::warn!(
-                "TreeViewHandler: WindowId {:?} not found for expand_all_tree_items",
-                window_id
-            );
-            PlatformError::InvalidHandle(format!(
-                "WindowId {:?} not found for expand_all_tree_items",
-                window_id
-            ))
-        })?;
-
-        let hwnd = window_data.get_control_hwnd(control_id).ok_or_else(|| {
-            log::warn!(
-                "TreeViewHandler: Control ID {} not found for expand_all_tree_items in WinID {:?}",
-                control_id,
-                window_id
-            );
-            PlatformError::InvalidHandle(format!(
-                "Control ID {} not found for expand_all_tree_items in WinID {:?}",
-                control_id, window_id
-            ))
-        })?;
-        hwnd
-    };
-
-    if hwnd_treeview.is_invalid() {
-        log::warn!(
-            "TreeViewHandler: HWND invalid for expand_all_tree_items in ControlID {}",
-            control_id
-        );
-        return Err(PlatformError::InvalidHandle(
-            "Invalid TreeView HWND for expand_all_tree_items".to_string(),
-        ));
-    }
+    let hwnd_treeview = get_treeview_hwnd(internal_state, window_id, control_id)?;
 
     use windows::Win32::UI::Controls::{
         TVE_EXPAND, TVGN_CHILD, TVGN_NEXT, TVGN_ROOT, TVM_EXPAND, TVM_GETNEXTITEM,
@@ -983,7 +637,6 @@ pub(crate) fn expand_all_tree_items(
  * Handles the NM_CUSTOMDRAW notification for a TreeView control.
  * This function orchestrates the custom drawing stages necessary to render a "New"
  * item indicator (a blue circle) next to items identified as new by the application logic.
- * It communicates with the `PlatformEventHandler` to query the "new" status of items.
  */
 pub(crate) fn handle_nm_customdraw(
     _internal_state: &Arc<Win32ApiInternalState>,
@@ -1004,69 +657,22 @@ pub(crate) fn handle_nm_customdraw(
             return LRESULT(CDRF_NOTIFYITEMDRAW as isize);
         }
         CDDS_ITEMPREPAINT => {
-            let tree_item_id_val = nmtvcd.nmcd.lItemlParam; // App-specific ID from lParam
-            let tree_item_id = TreeItemId(tree_item_id_val.0 as u64);
-            log::trace!(
-                "TreeViewHandler NM_CUSTOMDRAW (WinID {:?}/CtrlID {}): CDDS_ITEMPREPAINT for AppTreeItemId {:?}",
-                window_id,
-                control_id_of_treeview,
-                tree_item_id
-            );
-
+            let tree_item_id = TreeItemId(nmtvcd.nmcd.lItemlParam.0 as u64);
             if let Some(handler_arc) = event_handler_opt {
                 if let Ok(handler_guard) = handler_arc.lock() {
                     if handler_guard.is_tree_item_new(window_id, tree_item_id) {
-                        log::debug!(
-                            "TreeViewHandler NM_CUSTOMDRAW (WinID {:?}/CtrlID {}): Item {:?} IS NEW. Requesting CDRF_NOTIFYPOSTPAINT.",
-                            window_id,
-                            control_id_of_treeview,
-                            tree_item_id
-                        );
                         return LRESULT(CDRF_NOTIFYPOSTPAINT as isize);
-                    } else {
-                        log::trace!(
-                            "TreeViewHandler NM_CUSTOMDRAW (WinID {:?}/CtrlID {}): Item {:?} IS NOT NEW. Requesting CDRF_DODEFAULT.",
-                            window_id,
-                            control_id_of_treeview,
-                            tree_item_id
-                        );
                     }
-                } else {
-                    log::warn!(
-                        "TreeViewHandler NM_CUSTOMDRAW (WinID {:?}/CtrlID {}): Failed to lock event handler for ITEMPREPAINT. Defaulting for item {:?}.",
-                        window_id,
-                        control_id_of_treeview,
-                        tree_item_id
-                    );
                 }
-            } else {
-                log::warn!(
-                    "TreeViewHandler NM_CUSTOMDRAW (WinID {:?}/CtrlID {}): Event handler not available for ITEMPREPAINT. Defaulting for item {:?}.",
-                    window_id,
-                    control_id_of_treeview,
-                    tree_item_id
-                );
             }
             return LRESULT(CDRF_DODEFAULT as isize);
         }
         CDDS_ITEMPOSTPAINT => {
             let hdc = nmtvcd.nmcd.hdc;
-            let h_item_native = HTREEITEM(nmtvcd.nmcd.dwItemSpec as isize); // Native HTREEITEM
+            let h_item_native = HTREEITEM(nmtvcd.nmcd.dwItemSpec as isize);
             let hwnd_treeview = nmtvcd.nmcd.hdr.hwndFrom;
-            let tree_item_id_val = nmtvcd.nmcd.lItemlParam; // App-specific ID
-            let tree_item_id = TreeItemId(tree_item_id_val.0 as u64);
 
             let mut item_rect_text_part = RECT::default();
-            // To get rect for a specific item for drawing, it's common to put HTREEITEM in rect.left
-            // when calling TVM_GETITEMRECT with wParam = TRUE (text part only).
-            // Or, more simply, pass the HTREEITEM as part of the structure.
-            // For TVM_GETITEMRECT, rect.left seems to be an input for *which* item if item is not selected.
-            // The problem P3.2 description suggests TVM_GETITEMRECT with wParam=FALSE (full item)
-            // was returning narrow rects, and wParam=TRUE (text-only) might be better.
-
-            // Let's try to get the text-only rectangle as per P3.2 action plan.
-            // The HTREEITEM needs to be communicated to TVM_GETITEMRECT.
-            // A common way: copy h_item_native into the RECT's first field(s).
             unsafe {
                 *((&mut item_rect_text_part as *mut RECT) as *mut HTREEITEM) = h_item_native;
             }
@@ -1081,68 +687,28 @@ pub(crate) fn handle_nm_customdraw(
             };
 
             if get_rect_success.0 != 0 {
-                // Non-zero means success
-                // Position circle slightly to the left of the text rectangle's left edge
-                let circle_offset_x = -(CIRCLE_DIAMETER + 3); // Offset to the left of text, plus a small gap
+                let circle_offset_x = -(CIRCLE_DIAMETER + 3);
                 let x1 = item_rect_text_part.left + circle_offset_x;
-                // Vertically center the circle with the text rectangle
                 let y1 = item_rect_text_part.top
                     + (item_rect_text_part.bottom - item_rect_text_part.top - CIRCLE_DIAMETER) / 2;
                 let x2 = x1 + CIRCLE_DIAMETER;
                 let y2 = y1 + CIRCLE_DIAMETER;
-
-                log::debug!(
-                    "TreeViewHandler NM_CUSTOMDRAW (WinID {:?}/CtrlID {}): ITEMPOSTPAINT for AppTreeItemId {:?} (HTREEITEM {:?}). TextRect: {:?}. Drawing circle at ({},{},{},{})",
-                    window_id,
-                    control_id_of_treeview,
-                    tree_item_id,
-                    h_item_native,
-                    item_rect_text_part,
-                    x1,
-                    y1,
-                    x2,
-                    y2
-                );
 
                 unsafe {
                     let h_brush = CreateSolidBrush(CIRCLE_COLOR_BLUE);
                     if !h_brush.is_invalid() {
                         let old_brush = SelectObject(hdc, HGDIOBJ(h_brush.0));
                         _ = Ellipse(hdc, x1, y1, x2, y2);
-                        SelectObject(hdc, old_brush); // Restore original brush
-                        _ = DeleteObject(HGDIOBJ(h_brush.0)); // Delete created brush
-                    } else {
-                        log::error!(
-                            "TreeViewHandler NM_CUSTOMDRAW (WinID {:?}/CtrlID {}): Failed to create brush for 'New' indicator. LastError: {:?}",
-                            window_id,
-                            control_id_of_treeview,
-                            GetLastError()
-                        );
+                        SelectObject(hdc, old_brush);
+                        _ = DeleteObject(HGDIOBJ(h_brush.0));
                     }
                 }
-            } else {
-                log::warn!(
-                    // Changed from error to warn based on P3.2 (failure might be expected for non-visible)
-                    "TreeViewHandler NM_CUSTOMDRAW (WinID {:?}/CtrlID {}): TVM_GETITEMRECT (text-only) FAILED for HTREEITEM {:?} (AppTreeItemId {:?}). GetLastError: {:?}. Indicator not drawn.",
-                    window_id,
-                    control_id_of_treeview,
-                    h_item_native,
-                    tree_item_id,
-                    unsafe { GetLastError() }
-                );
             }
-            return LRESULT(CDRF_DODEFAULT as isize); // Finished custom drawing for this item
+            return LRESULT(CDRF_DODEFAULT as isize);
         }
-        _ => {
-            log::trace!(
-                "TreeViewHandler NM_CUSTOMDRAW (WinID {:?}/CtrlID {}): Unhandled dwDrawStage: {:?}",
-                window_id,
-                control_id_of_treeview,
-                nmtvcd.nmcd.dwDrawStage
-            );
-        }
+        _ => {}
     }
-    LRESULT(CDRF_DODEFAULT as isize) // Default for unhandled stages
+    LRESULT(CDRF_DODEFAULT as isize)
 }
 
 /*
@@ -1154,170 +720,115 @@ pub(crate) fn handle_nm_customdraw(
  */
 pub(crate) fn handle_wm_app_treeview_checkbox_clicked(
     internal_state: &Arc<Win32ApiInternalState>,
-    _parent_hwnd: HWND, // Unused for now, but was part of original signature
+    _parent_hwnd: HWND,
     window_id: WindowId,
     wparam_htreeitem: WPARAM,
     lparam_control_id: LPARAM,
 ) -> Option<AppEvent> {
-    let h_item_val = wparam_htreeitem.0 as isize;
+    let h_item_clicked = HTREEITEM(wparam_htreeitem.0 as isize);
     let control_id_of_treeview = lparam_control_id.0 as i32;
 
-    if h_item_val == 0 {
-        log::warn!(
-            "TreeViewHandler: WM_APP_TREEVIEW_CHECKBOX_CLICKED with null HTREEITEM in WPARAM for ControlID {}. Ignoring.",
-            control_id_of_treeview
-        );
-        return None;
-    }
-    if control_id_of_treeview == 0 {
-        log::warn!(
-            "TreeViewHandler: WM_APP_TREEVIEW_CHECKBOX_CLICKED with null ControlID in LPARAM for HTREEITEM {:?}. Ignoring.",
-            HTREEITEM(h_item_val)
-        );
+    if h_item_clicked.0 == 0 || control_id_of_treeview == 0 {
         return None;
     }
 
-    let h_item_clicked = HTREEITEM(h_item_val);
-    log::debug!(
-        "TreeViewHandler: handle_wm_app_treeview_checkbox_clicked for WinID {:?}, ControlID {}, HTREEITEM {:?}",
-        window_id,
-        control_id_of_treeview,
-        h_item_clicked
-    );
+    let result = internal_state.with_window_data_read(window_id, |window_data| {
+        let hwnd_treeview = window_data
+            .get_control_hwnd(control_id_of_treeview)
+            .ok_or_else(|| PlatformError::InvalidHandle("Control not found".into()))?;
+        let tv_state = window_data
+            .get_treeview_state()
+            .ok_or_else(|| PlatformError::OperationFailed("TreeView state not found".into()))?;
 
-    // Retrieve the HWND of the TreeView and its state
-    let windows_guard = internal_state.active_windows().read().ok()?;
-    let window_data = windows_guard.get(&window_id)?;
-    let hwnd_treeview = window_data.get_control_hwnd(control_id_of_treeview)?;
+        let mut tv_item_get = TVITEMEXW {
+            mask: TVIF_STATE | TVIF_PARAM,
+            hItem: h_item_clicked,
+            stateMask: TVIS_STATEIMAGEMASK.0,
+            ..Default::default()
+        };
 
-    let tv_state = window_data.get_treeview_state()?; // Ensure TreeView state exists
+        if unsafe {
+            SendMessageW(
+                hwnd_treeview,
+                TVM_GETITEMW,
+                Some(WPARAM(0)),
+                Some(LPARAM(&mut tv_item_get as *mut _ as isize)),
+            )
+        }
+        .0 == 0
+        {
+            return Err(PlatformError::OperationFailed("TVM_GETITEMW failed".into()));
+        }
 
-    // Get the item's current state (including checkbox state)
-    let mut tv_item_get = TVITEMEXW {
-        mask: TVIF_STATE | TVIF_PARAM, // Need state for checkbox and lParam for AppTreeItemId
-        hItem: h_item_clicked,
-        stateMask: TVIS_STATEIMAGEMASK.0,
-        lParam: LPARAM(0), // To retrieve the app-specific ID
-        ..Default::default()
-    };
-
-    let get_item_result = unsafe {
-        SendMessageW(
-            hwnd_treeview,
-            TVM_GETITEMW,
-            Some(WPARAM(0)), // Must be 0
-            Some(LPARAM(&mut tv_item_get as *mut _ as isize)),
-        )
-    };
-
-    if get_item_result.0 == 0 {
-        // TVM_GETITEMW returns 0 on failure
-        log::error!(
-            "TreeViewHandler: TVM_GETITEMW FAILED for HTREEITEM {:?} in ControlID {}. Error: {:?}",
-            h_item_clicked,
-            control_id_of_treeview,
-            unsafe { GetLastError() }
-        );
-        return None;
-    }
-
-    // State image index: 1 for unchecked, 2 for checked.
-    let state_image_idx = (tv_item_get.state & TVIS_STATEIMAGEMASK.0) >> 12;
-    let new_check_state = if state_image_idx == 2 {
-        // Item IS now checked
-        CheckState::Checked
-    } else {
-        // Item IS now unchecked (or indeterminate, which we map to unchecked)
-        CheckState::Unchecked
-    };
-
-    // Retrieve the application-specific TreeItemId stored in lParam.
-    // If lParam is 0 (e.g. not set during creation), try to map back from h_item_clicked.
-    let app_item_id_from_lparam = tv_item_get.lParam.0 as u64;
-    let app_item_id: TreeItemId;
-
-    if app_item_id_from_lparam != 0 {
-        app_item_id = TreeItemId(app_item_id_from_lparam);
-    } else {
-        // Fallback: try to find TreeItemId from htreeitem_to_item_id map
-        if let Some(mapped_id) = tv_state.htreeitem_to_item_id.get(&(h_item_clicked.0)) {
-            app_item_id = *mapped_id;
-            log::warn!(
-                "TreeViewHandler: AppTreeItemId was 0 from TVM_GETITEMW's lParam for HTREEITEM {:?}, but found {:?} via map.",
-                h_item_clicked,
-                app_item_id
-            );
+        let state_image_idx = (tv_item_get.state & TVIS_STATEIMAGEMASK.0) >> 12;
+        let new_check_state = if state_image_idx == 2 {
+            CheckState::Checked
         } else {
+            CheckState::Unchecked
+        };
+
+        let app_item_id = if tv_item_get.lParam.0 != 0 {
+            TreeItemId(tv_item_get.lParam.0 as u64)
+        } else {
+            // Fallback to map lookup
+            tv_state
+                .htreeitem_to_item_id
+                .get(&(h_item_clicked.0))
+                .copied()
+                .ok_or_else(|| PlatformError::InvalidHandle("HTREEITEM not found in map".into()))?
+        };
+
+        Ok(AppEvent::TreeViewItemToggledByUser {
+            window_id,
+            item_id: app_item_id,
+            new_state: new_check_state,
+        })
+    });
+
+    match result {
+        Ok(event) => Some(event),
+        Err(e) => {
             log::error!(
-                "TreeViewHandler: AppTreeItemId is 0 from TVM_GETITEMW's lParam AND HTREEITEM {:?} not found in htreeitem_to_item_id map for ControlID {}. Cannot generate event.",
+                "Failed to handle checkbox click for HTREEITEM {:?}: {:?}",
                 h_item_clicked,
-                control_id_of_treeview
+                e
             );
-            return None;
+            None
         }
     }
-    log::debug!(
-        "TreeViewHandler: Checkbox toggle processed. AppTreeItemId: {:?}, New UI CheckState: {:?}, ControlID: {}",
-        app_item_id,
-        new_check_state,
-        control_id_of_treeview
-    );
-
-    Some(AppEvent::TreeViewItemToggledByUser {
-        window_id,
-        item_id: app_item_id,
-        new_state: new_check_state,
-    })
 }
 
 /*
  * Handles general NM_CLICK notifications for a TreeView.
- * This function is called from window_common's WM_NOTIFY handler.
- * Its primary purpose is to detect clicks on a TreeView item's state icon (checkbox)
- * and, if detected, post a custom WM_APP_TREEVIEW_CHECKBOX_CLICKED message to the
- * parent window. This decouples the immediate click detection from the state update logic.
+ * This function's primary purpose is to detect clicks on a TreeView item's state
+ * icon (checkbox) and post a custom message for deferred processing.
  */
 pub(crate) fn handle_nm_click(
     _internal_state: &Arc<Win32ApiInternalState>,
     parent_hwnd: HWND,
-    window_id: WindowId,
+    _window_id: WindowId,
     nmhdr: &NMHDR,
 ) {
-    let hwnd_tv_from_notify = nmhdr.hwndFrom; // HWND of the TreeView control
+    let hwnd_tv_from_notify = nmhdr.hwndFrom;
     if hwnd_tv_from_notify.is_invalid() {
-        log::warn!("TreeViewHandler: NM_CLICK from invalid HWND. Ignoring.");
         return;
     }
 
     let control_id_from_notify = nmhdr.idFrom as i32;
-    log::trace!(
-        "TreeViewHandler: handle_nm_click for WinID {:?}, TreeView HWND {:?}, ControlID {}",
-        window_id,
-        hwnd_tv_from_notify,
-        control_id_from_notify
-    );
 
-    // Get cursor position in client coordinates of the TreeView
     let mut screen_pt_of_click = POINT::default();
     if unsafe { GetCursorPos(&mut screen_pt_of_click) }.is_err() {
-        log::warn!("TreeViewHandler: GetCursorPos failed in NM_CLICK. Cannot perform hit-test.");
         return;
     }
     let mut client_pt_for_hittest = screen_pt_of_click;
     if unsafe { ScreenToClient(hwnd_tv_from_notify, &mut client_pt_for_hittest) }.as_bool() == false
     {
-        log::warn!(
-            "TreeViewHandler: ScreenToClient failed in NM_CLICK. Cannot perform hit-test. Error: {:?}",
-            unsafe { GetLastError() }
-        );
         return;
     }
 
-    // Perform hit-test
     let mut tvht_info = TVHITTESTINFO {
         pt: client_pt_for_hittest,
-        flags: TVHITTESTINFO_FLAGS(0), // Will be filled by TVM_HITTEST
-        hItem: HTREEITEM(0),           // Will be filled by TVM_HITTEST
+        ..Default::default()
     };
 
     let h_item_hit = HTREEITEM(
@@ -1325,7 +836,7 @@ pub(crate) fn handle_nm_click(
             SendMessageW(
                 hwnd_tv_from_notify,
                 TVM_HITTEST,
-                Some(WPARAM(0)), // Must be 0
+                Some(WPARAM(0)),
                 Some(LPARAM(&mut tvht_info as *mut _ as isize)),
             )
         }
@@ -1333,33 +844,24 @@ pub(crate) fn handle_nm_click(
     );
 
     if h_item_hit.0 != 0 && (tvht_info.flags.0 & TVHT_ONITEMSTATEICON.0) != 0 {
-        // Click was on a state icon (checkbox)
         log::debug!(
-            "TreeViewHandler: NM_CLICK on state icon detected for HTREEITEM {:?} in ControlID {}. Posting WM_APP_TREEVIEW_CHECKBOX_CLICKED.",
+            "NM_CLICK on state icon detected for HTREEITEM {:?}. Posting deferred message.",
             h_item_hit,
-            control_id_from_notify
         );
         unsafe {
-            // Post message to parent window for deferred processing
             if PostMessageW(
-                Some(parent_hwnd), // Post to the main window that received WM_NOTIFY
+                Some(parent_hwnd),
                 crate::platform_layer::window_common::WM_APP_TREEVIEW_CHECKBOX_CLICKED,
-                WPARAM(h_item_hit.0 as usize), // Pass HTREEITEM in WPARAM
-                LPARAM(control_id_from_notify as isize), // Pass ControlID in LPARAM
+                WPARAM(h_item_hit.0 as usize),
+                LPARAM(control_id_from_notify as isize),
             )
             .is_err()
             {
                 log::error!(
-                    "TreeViewHandler: Failed to post WM_APP_TREEVIEW_CHECKBOX_CLICKED message: {:?}",
+                    "Failed to post WM_APP_TREEVIEW_CHECKBOX_CLICKED message: {:?}",
                     GetLastError()
                 );
             }
         }
-    } else {
-        log::trace!(
-            "TreeViewHandler: NM_CLICK was not on a state icon (flags: {:?}, hItem: {:?}).",
-            tvht_info.flags,
-            h_item_hit
-        );
     }
 }

--- a/src/platform_layer/controls/treeview_handler.rs
+++ b/src/platform_layer/controls/treeview_handler.rs
@@ -201,7 +201,7 @@ pub(crate) fn handle_create_treeview_command(
 
     // Phase 1: Acquire read lock, perform checks, and get necessary data for CreateWindowExW
     {
-        let windows_map_guard = internal_state.active_windows.read().map_err(|e|{
+        let windows_map_guard = internal_state.active_windows().read().map_err(|e|{
             log::error!("TreeViewHandler: Failed to lock windows map (read) for TreeView creation pre-check: {:?}", e);
             PlatformError::OperationFailed("Failed to lock windows map (read) for TreeView creation pre-check".into())
         })?;
@@ -269,7 +269,7 @@ pub(crate) fn handle_create_treeview_command(
 
     // Phase 3: Re-acquire write lock to update NativeWindowData
     {
-        let mut windows_map_guard = internal_state.active_windows.write().map_err(|e| {
+        let mut windows_map_guard = internal_state.active_windows().write().map_err(|e| {
             log::error!(
                 "TreeViewHandler: Failed to re-acquire write lock for TreeView creation post-update: {:?}",
                 e
@@ -346,7 +346,7 @@ pub(crate) fn populate_treeview(
 
     // Phase 1: Lock, get HWND, take tv_state
     {
-        let mut windows_map_guard = internal_state.active_windows.write().map_err(|e| {
+        let mut windows_map_guard = internal_state.active_windows().write().map_err(|e| {
             log::error!(
                 "TreeViewHandler: Failed to lock windows map for populate_treeview (phase 1): {:?}",
                 e
@@ -414,7 +414,7 @@ pub(crate) fn populate_treeview(
                 tv_state_actual.add_item_recursive_impl(hwnd_treeview, HTREEITEM(0), &item_desc)
             {
                 // Attempt to put state back on error
-                let mut windows_map_guard = internal_state.active_windows.write().map_err(|re_lock_err| {
+                let mut windows_map_guard = internal_state.active_windows().write().map_err(|re_lock_err| {
                     log::error!("TreeViewHandler: Failed to re-lock windows map for populate_treeview (error recovery): {:?}", re_lock_err);
                     // Original error `e` is more important, but log this too.
                     e.clone() // Return original error
@@ -449,7 +449,7 @@ pub(crate) fn populate_treeview(
 
     // Phase 3: Lock, put tv_state back
     {
-        let mut windows_map_guard = internal_state.active_windows.write().map_err(|e| {
+        let mut windows_map_guard = internal_state.active_windows().write().map_err(|e| {
             log::error!(
                 "TreeViewHandler: Failed to lock windows map for populate_treeview (phase 3): {:?}",
                 e
@@ -500,7 +500,7 @@ pub(crate) fn update_treeview_item_visual_state(
 
     {
         // Read lock scope
-        let windows_guard = internal_state.active_windows.read().map_err(|e|{
+        let windows_guard = internal_state.active_windows().read().map_err(|e|{
             log::error!("TreeViewHandler: Failed to acquire read lock for windows map (update visual): {:?}",e);
             PlatformError::OperationFailed("Failed to acquire read lock for windows map (update visual)".into())
         })?;
@@ -617,7 +617,7 @@ pub(crate) fn handle_treeview_itemchanged_notification(
     );
 
     // Ensure TreeView state exists for this control_id
-    let windows_guard = match internal_state.active_windows.read() {
+    let windows_guard = match internal_state.active_windows().read() {
         Ok(g) => g,
         Err(e) => {
             log::error!(
@@ -676,7 +676,7 @@ pub(crate) fn handle_redraw_tree_item_command(
 
     {
         // Read lock scope
-        let windows_guard = internal_state.active_windows.read().map_err(|e| {
+        let windows_guard = internal_state.active_windows().read().map_err(|e| {
             log::error!("TreeViewHandler: Failed to acquire read lock on windows map for RedrawTreeItem: {:?}", e);
             PlatformError::OperationFailed("Failed to lock active_windows map for RedrawTreeItem".into())
         })?;
@@ -785,7 +785,7 @@ pub(crate) fn expand_visible_tree_items(
     );
 
     let hwnd_treeview = {
-        let windows_guard = internal_state.active_windows.read().map_err(|e| {
+        let windows_guard = internal_state.active_windows().read().map_err(|e| {
             log::error!(
                 "TreeViewHandler: Failed to lock windows map (expand_visible_tree_items): {:?}",
                 e
@@ -876,7 +876,7 @@ pub(crate) fn expand_all_tree_items(
     );
 
     let hwnd_treeview = {
-        let windows_guard = internal_state.active_windows.read().map_err(|e| {
+        let windows_guard = internal_state.active_windows().read().map_err(|e| {
             log::error!(
                 "TreeViewHandler: Failed to lock windows map (expand_all_tree_items): {:?}",
                 e
@@ -1186,7 +1186,7 @@ pub(crate) fn handle_wm_app_treeview_checkbox_clicked(
     );
 
     // Retrieve the HWND of the TreeView and its state
-    let windows_guard = internal_state.active_windows.read().ok()?;
+    let windows_guard = internal_state.active_windows().read().ok()?;
     let window_data = windows_guard.get(&window_id)?;
     let hwnd_treeview = window_data.get_control_hwnd(control_id_of_treeview)?;
 

--- a/src/platform_layer/controls/treeview_handler.rs
+++ b/src/platform_layer/controls/treeview_handler.rs
@@ -231,7 +231,7 @@ pub(crate) fn handle_create_treeview_command(
             )));
         }
         hwnd_parent_for_creation = window_data.get_hwnd();
-        h_instance_for_creation = internal_state.h_instance;
+        h_instance_for_creation = internal_state.h_instance();
 
         if hwnd_parent_for_creation.is_invalid() {
             log::warn!(

--- a/src/platform_layer/dialog_handler.rs
+++ b/src/platform_layer/dialog_handler.rs
@@ -557,7 +557,7 @@ pub(crate) fn handle_show_input_dialog_command(
     // Show the modal dialog.
     let dialog_result = unsafe {
         DialogBoxIndirectParamW(
-            Some(internal_state.h_instance),
+            Some(internal_state.h_instance()),
             template_bytes.as_ptr() as *const DLGTEMPLATE,
             Some(hwnd_owner),
             Some(input_dialog_proc),

--- a/src/platform_layer/dialog_handler.rs
+++ b/src/platform_layer/dialog_handler.rs
@@ -49,7 +49,7 @@ pub(crate) fn get_hwnd_owner(
     internal_state: &Arc<Win32ApiInternalState>,
     window_id: WindowId,
 ) -> PlatformResult<HWND> {
-    let windows_guard = internal_state.active_windows.read().map_err(|_| {
+    let windows_guard = internal_state.active_windows().read().map_err(|_| {
         PlatformError::OperationFailed("Failed to acquire read lock on windows map".into())
     })?;
     windows_guard

--- a/src/platform_layer/dialog_handler.rs
+++ b/src/platform_layer/dialog_handler.rs
@@ -45,22 +45,30 @@ pub(crate) fn pathbuf_from_buf(buffer: &[u16]) -> PathBuf {
     PathBuf::from(path_os_string)
 }
 
+/*
+ * Retrieves the owner HWND for a given WindowId.
+ * This is a helper function that uses the with_window_data_read pattern to
+ * safely access the native window handle, encapsulating the locking and
+ * error handling logic.
+ */
 pub(crate) fn get_hwnd_owner(
     internal_state: &Arc<Win32ApiInternalState>,
     window_id: WindowId,
 ) -> PlatformResult<HWND> {
-    let windows_guard = internal_state.active_windows().read().map_err(|_| {
-        PlatformError::OperationFailed("Failed to acquire read lock on windows map".into())
-    })?;
-    windows_guard
-        .get(&window_id)
-        .map(|data| data.get_hwnd())
-        .ok_or_else(|| {
-            PlatformError::InvalidHandle(format!(
-                "WindowId {:?} not found for get_hwnd_owner",
+    internal_state.with_window_data_read(window_id, |window_data| {
+        let hwnd = window_data.get_hwnd();
+        if hwnd.is_invalid() {
+            log::warn!(
+                "get_hwnd_owner found an invalid HWND for WindowId {:?}",
                 window_id
-            ))
-        })
+            );
+            return Err(PlatformError::InvalidHandle(format!(
+                "HWND for WindowId {:?} is invalid",
+                window_id
+            )));
+        }
+        Ok(hwnd)
+    })
 }
 
 /*
@@ -86,7 +94,7 @@ where
     FEvent: FnOnce(WindowId, Option<PathBuf>) -> AppEvent,
 {
     // Retrieve the owner HWND for the dialog.
-    let hwnd_owner = get_hwnd_owner(internal_state, window_id)?; // get_hwnd_owner is in Win32ApiInternalState
+    let hwnd_owner = get_hwnd_owner(internal_state, window_id)?;
 
     // Prepare buffer for the file path.
     let mut file_buffer: Vec<u16> = vec![0; 2048]; // Buffer for the path.

--- a/src/platform_layer/window_common.rs
+++ b/src/platform_layer/window_common.rs
@@ -361,7 +361,7 @@ pub(crate) fn register_window_class(
     unsafe {
         let mut wc_test = WNDCLASSEXW::default();
         if GetClassInfoExW(
-            Some(internal_state.h_instance),
+            Some(internal_state.h_instance()),
             class_name_pcwstr,
             &mut wc_test,
         )
@@ -380,7 +380,7 @@ pub(crate) fn register_window_class(
             lpfnWndProc: Some(facade_wnd_proc_router),
             cbClsExtra: 0,
             cbWndExtra: 0,
-            hInstance: internal_state.h_instance,
+            hInstance: internal_state.h_instance(),
             hIcon: LoadIconW(None, IDI_APPLICATION)?,
             hCursor: LoadCursorW(None, IDC_ARROW)?,
             hbrBackground: HBRUSH((COLOR_WINDOW.0 + 1) as *mut c_void),
@@ -439,7 +439,7 @@ pub(crate) fn create_native_window(
             height,                              // Height
             None,                                // Parent window (None for top-level)
             None,                                // Menu (None for no default menu)
-            Some(internal_state_arc.h_instance), // Application instance
+            Some(internal_state_arc.h_instance()), // Application instance
             Some(Box::into_raw(creation_context) as *mut c_void), // lParam for WM_CREATE/WM_NCCREATE
         )?; // Returns Result<HWND, Error>, so ? operator handles error conversion
 

--- a/src/platform_layer/window_common.rs
+++ b/src/platform_layer/window_common.rs
@@ -1237,7 +1237,7 @@ pub(crate) fn set_window_title(
     title: &str,
 ) -> PlatformResult<()> {
     log::debug!("Setting title for WinID {:?} to '{}'", window_id, title);
-    let windows_guard = internal_state.active_windows.read().map_err(|_| {
+    let windows_guard = internal_state.active_windows().read().map_err(|_| {
         PlatformError::OperationFailed("Failed read lock for set_window_title".into())
     })?;
     let window_data = windows_guard.get(&window_id).ok_or_else(|| {
@@ -1315,7 +1315,7 @@ pub(crate) fn destroy_native_window(
     );
     let hwnd_to_destroy: Option<HWND>;
     {
-        let windows_read_guard = internal_state.active_windows.read().map_err(|e| {
+        let windows_read_guard = internal_state.active_windows().read().map_err(|e| {
             PlatformError::OperationFailed(format!(
                 "Failed read lock (destroy_native_window): {}",
                 e

--- a/src/platform_layer/window_common.rs
+++ b/src/platform_layer/window_common.rs
@@ -11,7 +11,7 @@
  */
 use super::{
     app::Win32ApiInternalState,
-    controls::{input_handler, label_handler, treeview_handler},
+    controls::{button_handler, input_handler, label_handler, treeview_handler},
     error::{PlatformError, Result as PlatformResult},
     types::{
         AppEvent, DockStyle, LayoutRule, MenuAction, MessageSeverity, PlatformEventHandler,
@@ -644,41 +644,12 @@ impl Win32ApiInternalState {
         let nmhdr = unsafe { &*nmhdr_ptr };
         let control_id_from_notify = nmhdr.idFrom as i32;
 
-        // Check if this notification is from a TreeView control associated with this window.
-        // This requires looking up the control by its ID and checking its class or type if needed,
-        // or simply assuming based on notification codes like NM_CUSTOMDRAW if they are unique enough.
-        // For now, we'll rely on treeview_state existing for the window and the notification code.
-        let is_treeview_notification;
-        {
-            let windows_guard = match self.active_windows().read() {
-                Ok(g) => g,
-                Err(e) => {
-                    log::error!(
-                        "Platform: Failed to get read lock in _handle_wm_notify_dispatch: {:?}",
-                        e
-                    );
-                    return (None, None);
-                }
-            };
-            let window_data = match windows_guard.get(&window_id) {
-                Some(wd) => wd,
-                None => {
-                    log::warn!(
-                        "Platform: WindowData not found for WinID {:?} in _handle_wm_notify_dispatch.",
-                        window_id
-                    );
-                    return (None, None);
-                }
-            };
-            // A simple check: does this window have treeview_state?
-            // And is the notification coming from the control ID stored for that treeview?
-            // For now, assume if treeview_state exists, this NM_CUSTOMDRAW or NM_CLICK could be for it.
-            // A more robust check would be to see if nmhdr.hwndFrom matches the stored TreeView HWND.
-            is_treeview_notification = window_data.has_treeview_state()
-                && window_data.get_control_hwnd(control_id_from_notify) == Some(nmhdr.hwndFrom);
-        }
+        let is_treeview_notification = self.with_window_data_read(window_id, |window_data| {
+            Ok(window_data.has_treeview_state()
+                && window_data.get_control_hwnd(control_id_from_notify) == Some(nmhdr.hwndFrom))
+        });
 
-        if is_treeview_notification {
+        if let Ok(true) = is_treeview_notification {
             match nmhdr.code {
                 NM_CUSTOMDRAW => {
                     log::trace!(
@@ -723,11 +694,11 @@ impl Win32ApiInternalState {
                     );
                 }
             }
-        } else {
-            log::trace!(
-                "WM_NOTIFY code {} from ControlID {} is not identified as a TreeView notification.",
-                nmhdr.code,
-                control_id_from_notify
+        } else if is_treeview_notification.is_err() {
+            log::error!(
+                "Failed to access window data for WM_NOTIFY in WinID {:?}: {:?}",
+                window_id,
+                is_treeview_notification.unwrap_err()
             );
         }
         (None, None)
@@ -735,8 +706,7 @@ impl Win32ApiInternalState {
 
     /*
      * Handles the WM_CREATE message for a window.
-     * Minimal responsibilities now, mainly for setting up things like custom fonts
-     * if they are window-wide and not control-specific.
+     * Ensures window-wide resources like custom fonts are created.
      */
     fn handle_wm_create(
         self: &Arc<Self>,
@@ -750,40 +720,55 @@ impl Win32ApiInternalState {
             hwnd,
             window_id
         );
-        if let Ok(mut windows_map_guard) = self.active_windows().write() {
-            if let Some(window_data) = windows_map_guard.get_mut(&window_id) {
-                window_data.ensure_status_bar_font();
-            }
+        if let Err(e) = self.with_window_data_write(window_id, |window_data| {
+            window_data.ensure_status_bar_font();
+            Ok(())
+        }) {
+            log::error!(
+                "Failed to access window data during WM_CREATE for WinID {:?}: {:?}",
+                window_id,
+                e
+            );
         }
     }
 
     /*
      * Applies layout rules recursively for a parent and its children.
+     * This function is the core of the layout engine. It iterates through the
+     * layout rules for a given parent, calculates the position and size for
+     * each child control based on its docking style, and then recurses for
+     * any children that are themselves containers.
      */
     fn apply_layout_rules_for_children(
         self: &Arc<Self>,
         window_id: WindowId,
         parent_id_for_layout: Option<i32>,
         parent_rect: RECT,
-        all_window_rules: &[LayoutRule],
-        all_controls_map: &HashMap<i32, HWND>,
+        window_data: &NativeWindowData,
     ) {
         log::trace!(
             "Applying layout for parent_id {:?}, rect: {:?}",
             parent_id_for_layout,
             parent_rect
         );
+
+        let all_window_rules = match &window_data.layout_rules {
+            Some(rules) => rules,
+            None => return, // No rules to apply
+        };
+
         let mut child_rules: Vec<&LayoutRule> = all_window_rules
             .iter()
             .filter(|r| r.parent_control_id == parent_id_for_layout)
             .collect();
         child_rules.sort_by_key(|r| r.order);
+
         let mut current_available_rect = parent_rect;
         let mut fill_candidates: Vec<(&LayoutRule, HWND)> = Vec::new();
         let mut proportional_fill_candidates: Vec<(&LayoutRule, HWND)> = Vec::new();
 
         for rule in &child_rules {
-            let control_hwnd_opt = all_controls_map.get(&rule.control_id).copied();
+            let control_hwnd_opt = window_data.control_hwnd_map.get(&rule.control_id).copied();
             if control_hwnd_opt.is_none() || control_hwnd_opt == Some(HWND_INVALID) {
                 log::warn!(
                     "Layout: HWND for control ID {} not found or invalid.",
@@ -846,8 +831,7 @@ impl Win32ApiInternalState {
                             window_id,
                             Some(rule.control_id),
                             panel_client_rect,
-                            all_window_rules,
-                            all_controls_map,
+                            window_data,
                         );
                     }
                 }
@@ -913,8 +897,7 @@ impl Win32ApiInternalState {
                                 window_id,
                                 Some(rule.control_id),
                                 panel_client_rect_prop,
-                                all_window_rules,
-                                all_controls_map,
+                                window_data,
                             );
                         }
                     }
@@ -961,8 +944,7 @@ impl Win32ApiInternalState {
                     window_id,
                     Some(rule.control_id),
                     panel_client_rect_fill,
-                    all_window_rules,
-                    all_controls_map,
+                    window_data,
                 );
             }
         }
@@ -976,54 +958,39 @@ impl Win32ApiInternalState {
             "trigger_layout_recalculation called for WinID {:?}",
             window_id
         );
-        let active_windows_guard = match self.active_windows().read() {
-            Ok(g) => g,
-            Err(e) => {
-                log::error!("Failed to get read lock for layout: {:?}", e);
-                return;
+
+        if let Err(e) = self.with_window_data_read(window_id, |window_data| {
+            if window_data.get_hwnd().is_invalid() {
+                log::warn!("HWND invalid for layout: {:?}", window_id);
+                return Ok(()); // Not an error, just can't do anything.
             }
-        };
-        let window_data = match active_windows_guard.get(&window_id) {
-            Some(d) => d,
-            None => {
-                log::warn!("WindowData not found for layout: {:?}", window_id);
-                return;
-            }
-        };
-        if window_data.this_window_hwnd.is_invalid() {
-            log::warn!("HWND invalid for layout: {:?}", window_id);
-            return;
-        }
-        let rules = match window_data.layout_rules.as_ref() {
-            Some(r) => r,
-            None => {
+            if window_data.layout_rules.is_none() {
                 log::debug!("No layout rules for WinID {:?}", window_id);
-                return;
+                return Ok(());
             }
-        };
-        if rules.is_empty() {
-            log::debug!("Empty layout rules for WinID {:?}", window_id);
-            return;
+
+            let mut client_rect = RECT::default();
+            if unsafe { GetClientRect(window_data.get_hwnd(), &mut client_rect) }.is_err() {
+                log::error!("GetClientRect failed for layout: {:?}", unsafe {
+                    GetLastError()
+                });
+                return Ok(());
+            }
+
+            log::trace!(
+                "Applying layout with client_rect: {:?}, for WinID {:?}",
+                client_rect,
+                window_id
+            );
+            self.apply_layout_rules_for_children(window_id, None, client_rect, window_data);
+            Ok(())
+        }) {
+            log::error!(
+                "Failed to access window data for layout recalculation of WinID {:?}: {:?}",
+                window_id,
+                e
+            );
         }
-        let mut client_rect = RECT::default();
-        if unsafe { GetClientRect(window_data.this_window_hwnd, &mut client_rect) }.is_err() {
-            log::error!("GetClientRect failed for layout: {:?}", unsafe {
-                GetLastError()
-            });
-            return;
-        }
-        log::trace!(
-            "Applying layout with client_rect: {:?}, for WinID {:?}",
-            client_rect,
-            window_id
-        );
-        self.apply_layout_rules_for_children(
-            window_id,
-            None,
-            client_rect,
-            &rules,
-            &window_data.control_hwnd_map,
-        );
     }
 
     /*
@@ -1067,37 +1034,35 @@ impl Win32ApiInternalState {
         let notification_code = highord_from_wparam(wparam);
         if control_hwnd.0 == 0 {
             // Menu or accelerator
-            if let Ok(windows_guard) = self.active_windows().read() {
-                if let Some(window_data) = windows_guard.get(&window_id) {
-                    if let Some(action) = window_data.get_menu_action(command_id) {
-                        log::debug!(
-                            "Menu action {:?} (ID {}) for WinID {:?}.",
-                            action,
-                            command_id,
-                            window_id
-                        );
-                        return Some(AppEvent::MenuActionClicked { action });
-                    } else {
-                        log::warn!(
-                            "WM_COMMAND (Menu/Accel) for unknown ID {} in WinID {:?}.",
-                            command_id,
-                            window_id
-                        );
-                    }
-                } else {
-                    log::warn!(
-                        "WindowData not found for WinID {:?} in WM_COMMAND (Menu/Accel).",
+            let menu_action_result =
+                self.with_window_data_read(window_id, |wd| Ok(wd.get_menu_action(command_id)));
+
+            match menu_action_result {
+                Ok(Some(action)) => {
+                    log::debug!(
+                        "Menu action {:?} (ID {}) for WinID {:?}.",
+                        action,
+                        command_id,
                         window_id
                     );
+                    return Some(AppEvent::MenuActionClicked { action });
                 }
-            } else {
-                log::error!("Failed read lock for menu_action_map in WM_COMMAND (Menu/Accel).");
+                Ok(None) => log::warn!(
+                    "WM_COMMAND (Menu/Accel) for unknown ID {} in WinID {:?}.",
+                    command_id,
+                    window_id
+                ),
+                Err(e) => log::error!(
+                    "Failed to access window data for WM_COMMAND (Menu/Accel) in WinID {:?}: {:?}",
+                    window_id,
+                    e
+                ),
             }
         } else {
-            // Control
+            // Control notification
             let hwnd_control = HWND(control_hwnd.0 as *mut std::ffi::c_void);
             if notification_code == BN_CLICKED as i32 {
-                return Some(super::controls::button_handler::handle_bn_clicked(
+                return Some(button_handler::handle_bn_clicked(
                     window_id,
                     command_id,
                     hwnd_control,
@@ -1139,11 +1104,15 @@ impl Win32ApiInternalState {
             _ = KillTimer(Some(hwnd), timer_id.0 as usize);
         }
         let control_id = timer_id.0 as i32;
-        let hwnd_edit_opt = self.active_windows().read().ok().and_then(|g| {
-            g.get(&window_id)
-                .and_then(|wd| wd.get_control_hwnd(control_id))
+
+        let hwnd_edit_result = self.with_window_data_read(window_id, |window_data| {
+            window_data.get_control_hwnd(control_id).ok_or_else(|| {
+                log::warn!("Control not found for timer ID {}", control_id);
+                PlatformError::InvalidHandle("Control not found for timer".into())
+            })
         });
-        if let Some(hwnd_edit) = hwnd_edit_opt {
+
+        if let Ok(hwnd_edit) = hwnd_edit_result {
             let mut buf: [u16; 256] = [0; 256];
             let len = unsafe { GetWindowTextW(hwnd_edit, &mut buf) } as usize;
             let text = String::from_utf16_lossy(&buf[..len]);
@@ -1154,6 +1123,10 @@ impl Win32ApiInternalState {
 
     /*
      * Handles WM_DESTROY: Cleans up resources and removes window data.
+     * Note: This function CANNOT use `with_window_data_write` because its purpose
+     * is to REMOVE the entry from the map, which is a map-level operation, not
+     * a data-level one. This is one of the few places where direct locking
+     * of `active_windows` is still necessary and appropriate.
      */
     fn handle_wm_destroy(
         self: &Arc<Self>,
@@ -1237,23 +1210,17 @@ pub(crate) fn set_window_title(
     title: &str,
 ) -> PlatformResult<()> {
     log::debug!("Setting title for WinID {:?} to '{}'", window_id, title);
-    let windows_guard = internal_state.active_windows().read().map_err(|_| {
-        PlatformError::OperationFailed("Failed read lock for set_window_title".into())
-    })?;
-    let window_data = windows_guard.get(&window_id).ok_or_else(|| {
-        PlatformError::InvalidHandle(format!(
-            "WindowId {:?} not found for set_window_title",
-            window_id
-        ))
-    })?;
-    if window_data.this_window_hwnd.is_invalid() {
-        return Err(PlatformError::InvalidHandle(format!(
-            "HWND for WinID {:?} invalid in set_window_title",
-            window_id
-        )));
-    }
-    unsafe { SetWindowTextW(window_data.this_window_hwnd, &HSTRING::from(title))? };
-    Ok(())
+    internal_state.with_window_data_read(window_id, |window_data| {
+        let hwnd = window_data.get_hwnd();
+        if hwnd.is_invalid() {
+            return Err(PlatformError::InvalidHandle(format!(
+                "HWND for WinID {:?} is invalid in set_window_title",
+                window_id
+            )));
+        }
+        unsafe { SetWindowTextW(hwnd, &HSTRING::from(title))? };
+        Ok(())
+    })
 }
 
 pub(crate) fn show_window(
@@ -1262,25 +1229,18 @@ pub(crate) fn show_window(
     show: bool,
 ) -> PlatformResult<()> {
     log::debug!("Setting visibility for WinID {:?} to {}", window_id, show);
-    let windows_guard = internal_state
-        .active_windows()
-        .read()
-        .map_err(|_| PlatformError::OperationFailed("Failed read lock for show_window".into()))?;
-    let window_data = windows_guard.get(&window_id).ok_or_else(|| {
-        PlatformError::InvalidHandle(format!(
-            "WindowId {:?} not found for show_window",
-            window_id
-        ))
-    })?;
-    if window_data.this_window_hwnd.is_invalid() {
-        return Err(PlatformError::InvalidHandle(format!(
-            "HWND for WinID {:?} invalid in show_window",
-            window_id
-        )));
-    }
-    let cmd = if show { SW_SHOW } else { SW_HIDE };
-    unsafe { _ = ShowWindow(window_data.this_window_hwnd, cmd) };
-    Ok(())
+    internal_state.with_window_data_read(window_id, |window_data| {
+        let hwnd = window_data.get_hwnd();
+        if hwnd.is_invalid() {
+            return Err(PlatformError::InvalidHandle(format!(
+                "HWND for WinID {:?} is invalid in show_window",
+                window_id
+            )));
+        }
+        let cmd = if show { SW_SHOW } else { SW_HIDE };
+        unsafe { _ = ShowWindow(hwnd, cmd) };
+        Ok(())
+    })
 }
 
 /*
@@ -1313,21 +1273,12 @@ pub(crate) fn destroy_native_window(
         "Attempting to destroy native window for WinID {:?}",
         window_id
     );
-    let hwnd_to_destroy: Option<HWND>;
-    {
-        let windows_read_guard = internal_state.active_windows().read().map_err(|e| {
-            PlatformError::OperationFailed(format!(
-                "Failed read lock (destroy_native_window): {}",
-                e
-            ))
-        })?;
-        hwnd_to_destroy = windows_read_guard
-            .get(&window_id)
-            .map(|data| data.this_window_hwnd);
-    }
 
-    if let Some(hwnd) = hwnd_to_destroy {
-        if !hwnd.is_invalid() {
+    let hwnd_to_destroy =
+        internal_state.with_window_data_read(window_id, |window_data| Ok(window_data.get_hwnd()));
+
+    match hwnd_to_destroy {
+        Ok(hwnd) if !hwnd.is_invalid() => {
             log::debug!(
                 "Calling DestroyWindow for HWND {:?} (WinID {:?})",
                 hwnd,
@@ -1336,9 +1287,9 @@ pub(crate) fn destroy_native_window(
             unsafe {
                 if DestroyWindow(hwnd).is_err() {
                     let last_error = GetLastError();
+                    // Don't error out if the handle is already invalid (e.g., already destroyed).
                     if last_error.0 != ERROR_INVALID_WINDOW_HANDLE.0 {
                         log::error!("DestroyWindow for HWND {:?} failed: {:?}", hwnd, last_error);
-                        // Optionally return error: PlatformError::OperationFailed(format!("DestroyWindow failed: {:?}", last_error))
                     } else {
                         log::debug!(
                             "DestroyWindow for HWND {:?} reported invalid handle (already destroyed?).",
@@ -1352,14 +1303,19 @@ pub(crate) fn destroy_native_window(
                     );
                 }
             }
-        } else {
+        }
+        Ok(_) => {
+            // HWND is invalid
             log::warn!(
                 "HWND for WinID {:?} was invalid before DestroyWindow call.",
                 window_id
             );
         }
-    } else {
-        log::warn!("WinID {:?} not found for destroy_native_window.", window_id);
-    }
+        Err(_) => {
+            // WindowId not found
+            log::warn!("WinID {:?} not found for destroy_native_window.", window_id);
+        }
+    };
+    // This function's purpose is to *try* to destroy, so don't bubble up "not found" as an error.
     Ok(())
 }


### PR DESCRIPTION
## Summary
- encapsulate `h_instance` in `Win32ApiInternalState`
- add accessor `h_instance()`
- adjust all call sites to use the accessor

## Testing
- `cargo test --quiet`
- `rustup component add rustfmt` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_684c6f9a5f88832cab1eaf70cc29027a