### PR TITLE
Make internal fields private

### DIFF
--- a/src/platform_layer/app.rs
+++ b/src/platform_layer/app.rs
@@ -36,9 +36,9 @@ pub(crate) struct Win32ApiInternalState {
     next_window_id_counter: AtomicUsize, // For generating unique WindowIds
     // Central registry for all active windows, mapping WindowId to its native state.
     active_windows: RwLock<HashMap<WindowId, window_common::NativeWindowData>>,
-    pub(crate) application_event_handler: Mutex<Option<Weak<Mutex<dyn PlatformEventHandler>>>>,
+    application_event_handler: Mutex<Option<Weak<Mutex<dyn PlatformEventHandler>>>>,
     // The application name, used for window class registration.
-    pub(crate) app_name_for_class: String,
+    app_name_for_class: String,
     is_quitting: AtomicUsize, // 0 = false, 1 = true
 }
 
@@ -63,6 +63,16 @@ impl Win32ApiInternalState {
         &self,
     ) -> &RwLock<HashMap<WindowId, window_common::NativeWindowData>> {
         &self.active_windows
+    }
+
+    pub(crate) fn application_event_handler(
+        &self,
+    ) -> &Mutex<Option<Weak<Mutex<dyn PlatformEventHandler>>>> {
+        &self.application_event_handler
+    }
+
+    pub(crate) fn app_name_for_class(&self) -> &str {
+        &self.app_name_for_class
     }
 
     /*
@@ -614,7 +624,7 @@ impl PlatformInterface {
     ) -> PlatformResult<()> {
         *self
             .internal_state
-            .application_event_handler
+            .application_event_handler()
             .lock()
             .map_err(|e| {
                 log::error!(
@@ -717,7 +727,7 @@ impl PlatformInterface {
             log::error!("Platform: Failed to lock application logic for on_quit call.");
         }
         // Clear the event handler reference
-        match self.internal_state.application_event_handler.lock() {
+        match self.internal_state.application_event_handler().lock() {
             Ok(mut guard) => *guard = None,
             Err(e) => {
                 log::error!(

--- a/src/platform_layer/dialog_handler.rs
+++ b/src/platform_layer/dialog_handler.rs
@@ -154,7 +154,7 @@ where
     // Construct and send the event to the application logic.
     let event = event_constructor(window_id, path_result);
     if let Some(handler_arc) = internal_state
-        .application_event_handler
+        .application_event_handler()
         .lock()
         .unwrap()
         .as_ref()
@@ -281,7 +281,7 @@ pub(crate) fn handle_show_profile_selection_dialog_command(
     };
 
     if let Some(handler_arc) = internal_state
-        .application_event_handler
+        .application_event_handler()
         .lock()
         .unwrap()
         .as_ref()
@@ -593,7 +593,7 @@ pub(crate) fn handle_show_input_dialog_command(
     };
 
     if let Some(handler_arc) = internal_state
-        .application_event_handler
+        .application_event_handler()
         .lock()
         .unwrap()
         .as_ref()
@@ -710,7 +710,7 @@ pub(crate) fn handle_show_folder_picker_dialog_command(
             path: None,
         };
         if let Some(handler_arc) = internal_state
-            .application_event_handler
+            .application_event_handler()
             .lock()
             .unwrap()
             .as_ref()
@@ -728,7 +728,7 @@ pub(crate) fn handle_show_folder_picker_dialog_command(
         path: path_result,
     };
     if let Some(handler_arc) = internal_state
-        .application_event_handler
+        .application_event_handler()
         .lock()
         .unwrap()
         .as_ref()

--- a/src/platform_layer/dialog_handler.rs
+++ b/src/platform_layer/dialog_handler.rs
@@ -153,21 +153,7 @@ where
 
     // Construct and send the event to the application logic.
     let event = event_constructor(window_id, path_result);
-    if let Some(handler_arc) = internal_state
-        .application_event_handler()
-        .lock()
-        .unwrap()
-        .as_ref()
-        .and_then(|wh| wh.upgrade())
-    {
-        if let Ok(mut handler_guard) = handler_arc.lock() {
-            handler_guard.handle_event(event);
-        } else {
-            log::error!("DialogHandler: Failed to lock event handler after dialog completion.");
-        }
-    } else {
-        log::error!("DialogHandler: Event handler not available after dialog completion.");
-    }
+    internal_state.send_event(event);
     Ok(())
 }
 
@@ -280,25 +266,7 @@ pub(crate) fn handle_show_profile_selection_dialog_command(
         user_cancelled: cancelled,
     };
 
-    if let Some(handler_arc) = internal_state
-        .application_event_handler()
-        .lock()
-        .unwrap()
-        .as_ref()
-        .and_then(|wh| wh.upgrade())
-    {
-        if let Ok(mut handler_guard) = handler_arc.lock() {
-            handler_guard.handle_event(event);
-        } else {
-            log::error!(
-                "DialogHandler: Failed to lock event handler for ProfileSelectionDialogCompleted."
-            );
-        }
-    } else {
-        log::error!(
-            "DialogHandler: Event handler not available for ProfileSelectionDialogCompleted."
-        );
-    }
+    internal_state.send_event(event);
     Ok(())
 }
 
@@ -592,23 +560,7 @@ pub(crate) fn handle_show_input_dialog_command(
         context_tag,
     };
 
-    if let Some(handler_arc) = internal_state
-        .application_event_handler()
-        .lock()
-        .unwrap()
-        .as_ref()
-        .and_then(|wh| wh.upgrade())
-    {
-        if let Ok(mut handler_guard) = handler_arc.lock() {
-            handler_guard.handle_event(event);
-        } else {
-            log::error!(
-                "DialogHandler: Failed to lock event handler for GenericInputDialogCompleted."
-            );
-        }
-    } else {
-        log::error!("DialogHandler: Event handler not available for GenericInputDialogCompleted.");
-    }
+    internal_state.send_event(event);
     Ok(())
 }
 
@@ -709,17 +661,7 @@ pub(crate) fn handle_show_folder_picker_dialog_command(
             window_id,
             path: None,
         };
-        if let Some(handler_arc) = internal_state
-            .application_event_handler()
-            .lock()
-            .unwrap()
-            .as_ref()
-            .and_then(|wh| wh.upgrade())
-        {
-            if let Ok(mut handler_guard) = handler_arc.lock() {
-                handler_guard.handle_event(event);
-            }
-        }
+        internal_state.send_event(event);
         return Err(PlatformError::OperationFailed(err_msg));
     }
 
@@ -727,22 +669,6 @@ pub(crate) fn handle_show_folder_picker_dialog_command(
         window_id,
         path: path_result,
     };
-    if let Some(handler_arc) = internal_state
-        .application_event_handler()
-        .lock()
-        .unwrap()
-        .as_ref()
-        .and_then(|wh| wh.upgrade())
-    {
-        if let Ok(mut handler_guard) = handler_arc.lock() {
-            handler_guard.handle_event(event);
-        } else {
-            log::error!(
-                "DialogHandler: Failed to lock event handler for FolderPickerDialogCompleted."
-            );
-        }
-    } else {
-        log::error!("DialogHandler: Event handler not available for FolderPickerDialogCompleted.");
-    }
+    internal_state.send_event(event);
     Ok(())
 }

--- a/src/platform_layer/window_common.rs
+++ b/src/platform_layer/window_common.rs
@@ -516,13 +516,6 @@ impl Win32ApiInternalState {
         lparam: LPARAM,
         window_id: WindowId,
     ) -> LRESULT {
-        let event_handler_opt = self
-            .application_event_handler()
-            .lock()
-            .unwrap()
-            .as_ref()
-            .and_then(|weak_handler| weak_handler.upgrade());
-
         let mut event_to_send: Option<AppEvent> = None;
         let mut lresult_override: Option<LRESULT> = None;
 
@@ -555,13 +548,8 @@ impl Win32ApiInternalState {
                 lresult_override = Some(self.handle_wm_paint(hwnd, wparam, lparam, window_id));
             }
             WM_NOTIFY => {
-                (event_to_send, lresult_override) = self._handle_wm_notify_dispatch(
-                    hwnd,
-                    wparam,
-                    lparam,
-                    window_id,
-                    event_handler_opt.as_ref(),
-                );
+                (event_to_send, lresult_override) =
+                    self._handle_wm_notify_dispatch(hwnd, wparam, lparam, window_id);
             }
             WM_APP_TREEVIEW_CHECKBOX_CLICKED => {
                 event_to_send = treeview_handler::handle_wm_app_treeview_checkbox_clicked(
@@ -598,21 +586,7 @@ impl Win32ApiInternalState {
         }
 
         if let Some(event) = event_to_send {
-            if let Some(handler_arc) = event_handler_opt {
-                if let Ok(mut handler_guard) = handler_arc.lock() {
-                    handler_guard.handle_event(event);
-                } else {
-                    log::error!(
-                        "Platform: Failed to lock event handler for event {:?}.",
-                        event
-                    );
-                }
-            } else {
-                log::warn!(
-                    "Platform: Event handler not available for event {:?}.",
-                    event
-                );
-            }
+            self.send_event(event);
         }
 
         if let Some(lresult) = lresult_override {
@@ -634,7 +608,6 @@ impl Win32ApiInternalState {
         _wparam_original: WPARAM,
         lparam_original: LPARAM,
         window_id: WindowId,
-        event_handler_opt: Option<&Arc<Mutex<dyn PlatformEventHandler>>>,
     ) -> (Option<AppEvent>, Option<LRESULT>) {
         let nmhdr_ptr = lparam_original.0 as *const NMHDR;
         if nmhdr_ptr.is_null() {
@@ -660,7 +633,6 @@ impl Win32ApiInternalState {
                         self,
                         window_id,
                         lparam_original,
-                        event_handler_opt,
                         control_id_from_notify,
                     );
                     return (None, Some(lresult));

--- a/src/platform_layer/window_common.rs
+++ b/src/platform_layer/window_common.rs
@@ -354,7 +354,7 @@ pub(crate) fn register_window_class(
 ) -> PlatformResult<()> {
     let class_name_hstring = HSTRING::from(format!(
         "{}_PlatformWindowClass",
-        internal_state.app_name_for_class
+        internal_state.app_name_for_class()
     ));
     let class_name_pcwstr = PCWSTR(class_name_hstring.as_ptr());
 
@@ -369,7 +369,7 @@ pub(crate) fn register_window_class(
         {
             log::debug!(
                 "Platform: Window class '{}' already registered.",
-                internal_state.app_name_for_class
+                internal_state.app_name_for_class()
             );
             return Ok(());
         }
@@ -399,7 +399,7 @@ pub(crate) fn register_window_class(
         } else {
             log::debug!(
                 "Platform: Window class '{}' registered successfully.",
-                internal_state.app_name_for_class
+                internal_state.app_name_for_class()
             );
             Ok(())
         }
@@ -419,7 +419,7 @@ pub(crate) fn create_native_window(
 ) -> PlatformResult<HWND> {
     let class_name_hstring = HSTRING::from(format!(
         "{}_PlatformWindowClass",
-        internal_state_arc.app_name_for_class
+        internal_state_arc.app_name_for_class()
     ));
 
     let creation_context = Box::new(WindowCreationContext {
@@ -517,7 +517,7 @@ impl Win32ApiInternalState {
         window_id: WindowId,
     ) -> LRESULT {
         let event_handler_opt = self
-            .application_event_handler
+            .application_event_handler()
             .lock()
             .unwrap()
             .as_ref()


### PR DESCRIPTION
## Summary
- keep `Win32ApiInternalState` fields private
- add accessors for `application_event_handler` and `app_name_for_class`
- update platform layer modules to use new accessors

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684d0a8da5f4832cb03490a79f2e0dea