### PR TITLE
Resolve some clippy warnings

### DIFF
--- a/src/app_logic/handler.rs
+++ b/src/app_logic/handler.rs
@@ -300,7 +300,7 @@ impl MyAppLogic {
             status
         );
 
-        ui_state_mut.current_archive_status_for_ui = Some(status.clone());
+        ui_state_mut.current_archive_status_for_ui = Some(status);
 
         let plain_status_string = Self::archive_status_to_plain_string(&status);
         let archive_label_text = format!("Archive: {}", plain_status_string);
@@ -357,7 +357,7 @@ impl MyAppLogic {
         if !self
             .ui_state
             .as_ref()
-            .map_or(false, |s| s.window_id == window_id)
+            .is_some_and(|s| s.window_id == window_id)
         {
             return;
         }
@@ -369,7 +369,7 @@ impl MyAppLogic {
         if self
             .ui_state
             .as_ref()
-            .map_or(false, |s| s.window_id == window_id)
+            .is_some_and(|s| s.window_id == window_id)
         {
             log::debug!(
                 "AppLogic: Main window (ID: {:?}) destroyed notification received. Clearing UI state.",
@@ -684,7 +684,7 @@ impl MyAppLogic {
         if !self
             .ui_state
             .as_ref()
-            .map_or(false, |s| s.window_id == window_id)
+            .is_some_and(|s| s.window_id == window_id)
         {
             log::warn!(
                 "FileOpenProfileDialogCompleted for non-matching or non-existent UI state. Window ID: {:?}. Ignoring.",
@@ -1086,7 +1086,7 @@ impl MyAppLogic {
         assert!(
             self.ui_state
                 .as_ref()
-                .map_or(false, |s| s.window_id == window_id),
+                .is_some_and(|s| s.window_id == window_id),
             "Mismatched window ID or no UI state for _activate_profile_and_show_window"
         );
 
@@ -1140,7 +1140,7 @@ impl MyAppLogic {
         assert!(
             self.ui_state
                 .as_ref()
-                .map_or(false, |s| s.window_id == window_id),
+                .is_some_and(|s| s.window_id == window_id),
             "initiate_profile_selection_or_creation called with mismatching window ID or no UI state."
         );
 
@@ -1195,7 +1195,7 @@ impl MyAppLogic {
         if !self
             .ui_state
             .as_ref()
-            .map_or(false, |s| s.window_id == window_id)
+            .is_some_and(|s| s.window_id == window_id)
         {
             log::debug!(
                 "ProfileSelectionDialogCompleted for non-matching or non-existent UI state. Window ID: {:?}. Ignoring.",
@@ -1364,7 +1364,7 @@ impl MyAppLogic {
         if !self
             .ui_state
             .as_ref()
-            .map_or(false, |s| s.window_id == window_id)
+            .is_some_and(|s| s.window_id == window_id)
         {
             log::warn!(
                 "InputDialogCompleted for an unknown or non-main window (ID: {:?}). Ignoring.",
@@ -1488,7 +1488,7 @@ impl MyAppLogic {
         assert!(
             self.ui_state
                 .as_ref()
-                .map_or(false, |s| s.window_id == window_id),
+                .is_some_and(|s| s.window_id == window_id),
             "_update_window_title_with_profile_and_archive called with mismatching window ID or no UI state."
         );
 
@@ -1540,7 +1540,7 @@ impl MyAppLogic {
         let initial_dir_for_dialog = current_archive_path_opt
             .as_ref()
             .and_then(|ap| ap.parent().map(PathBuf::from))
-            .or_else(|| Some(current_root_path));
+            .or(Some(current_root_path));
 
         self.synchronous_command_queue
             .push_back(PlatformCommand::ShowSaveFileDialog {

--- a/src/app_logic/handler_tests.rs
+++ b/src/app_logic/handler_tests.rs
@@ -1,4 +1,3 @@
-#![cfg(test)]
 
 use crate::app_logic::handler::*;
 use crate::app_logic::ui_constants;
@@ -23,6 +22,17 @@ use std::sync::{
 };
 use std::time::SystemTime;
 
+type ApplySelStatesCall = (Vec<FileNode>, HashSet<PathBuf>, HashSet<PathBuf>);
+type TestSetup = (
+    MyAppLogic,
+    Arc<Mutex<MockProfileRuntimeData>>,
+    Arc<MockConfigManager>,
+    Arc<MockProfileManager>,
+    Arc<MockFileSystemScanner>,
+    Arc<MockArchiver>,
+    Arc<MockStateManager>,
+    Arc<MockTokenCounter>,
+);
     /*
      * This module contains unit tests for `MyAppLogic` from the `super::handler` module.
      * It utilizes mock implementations of core dependencies, including a new
@@ -1009,18 +1019,7 @@ use std::time::SystemTime;
                 .unwrap_or(&self.default_count)
         }
     }
-
-    fn setup_logic_with_mocks() -> (
-        MyAppLogic,
-        Arc<Mutex<MockProfileRuntimeData>>,
-        Arc<MockConfigManager>,
-        Arc<MockProfileManager>,
-        Arc<MockFileSystemScanner>,
-        Arc<MockArchiver>,
-        Arc<MockStateManager>,
-        Arc<MockTokenCounter>,
-    ) {
-        crate::initialize_logging();
+    fn setup_logic_with_mocks() -> TestSetup {
         let mock_app_session_data_for_test = Arc::new(Mutex::new(MockProfileRuntimeData::new()));
         let mock_config_manager_arc = Arc::new(MockConfigManager::new());
         let mock_profile_manager_arc = Arc::new(MockProfileManager::new());
@@ -1050,22 +1049,20 @@ use std::time::SystemTime;
             mock_token_counter_arc,
         )
     }
-
-    fn find_command<'a, F>(
-        cmds: &'a [PlatformCommand],
+    fn find_command<F>(
+        cmds: &[PlatformCommand],
         mut predicate: F,
-    ) -> Option<&'a PlatformCommand>
+    ) -> Option<&PlatformCommand>
     where
         F: FnMut(&PlatformCommand) -> bool,
     {
         cmds.iter().find(|&cmd| predicate(cmd))
     }
 
-    // Helper to find multiple commands matching a predicate
-    fn find_commands<'a, F>(
-        cmds: &'a [PlatformCommand],
+    fn find_commands<F>(
+        cmds: &[PlatformCommand],
         mut predicate: F,
-    ) -> Vec<&'a PlatformCommand>
+    ) -> Vec<&PlatformCommand>
     where
         F: FnMut(&PlatformCommand) -> bool,
     {

--- a/src/core/file_node.rs
+++ b/src/core/file_node.rs
@@ -10,17 +10,12 @@ use crate::platform_layer::{CheckState, TreeItemDescriptor, TreeItemId};
  * Derives Serialize and Deserialize for potential future use if this enum is directly part of a complex state
  * (though current Profile doesn't serialize it directly). Default is added for convenience.
  */
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum SelectionState {
     Selected,
     Deselected,
+    #[default]
     New,
-}
-
-impl Default for SelectionState {
-    fn default() -> Self {
-        SelectionState::New
-    }
 }
 
 /*
@@ -297,7 +292,7 @@ mod tests {
         let n = FileNode::new_test(p.clone(), "foo".into(), false);
         assert_eq!(n.path(), p.as_path());
         assert_eq!(n.name(), "foo");
-        assert_eq!(n.is_dir(), false);
+        assert!(!n.is_dir());
         assert_eq!(n.state, SelectionState::New);
         assert!(n.children.is_empty());
     }
@@ -381,7 +376,7 @@ mod tests {
         // Dir 1
         assert_eq!(descriptors[1].text, "dir1");
         assert_eq!(descriptors[1].id, TreeItemId(101));
-        assert_eq!(descriptors[1].is_folder, true);
+        assert!(descriptors[1].is_folder);
         assert_eq!(descriptors[1].state, CheckState::Unchecked); // New/Deselected map to Unchecked
         assert_eq!(
             path_to_id_map.get(&PathBuf::from("/dir1")),

--- a/src/core/file_system.rs
+++ b/src/core/file_system.rs
@@ -143,7 +143,7 @@ impl FileSystemScannerOperations for CoreFileSystemScanner {
             let path = entry.path().to_path_buf();
             // Use file_name from DirEntry as it's relative to its parent.
             let name = entry.file_name().to_string_lossy().into_owned();
-            let is_dir = entry.file_type().map_or(false, |ft| ft.is_dir());
+            let is_dir = entry.file_type().is_some_and(|ft| ft.is_dir());
 
             let checksum_str;
             if !is_dir {
@@ -211,7 +211,7 @@ impl FileSystemScannerOperations for CoreFileSystemScanner {
     }
 }
 
-fn sort_file_nodes_recursively(nodes: &mut Vec<FileNode>) {
+fn sort_file_nodes_recursively(nodes: &mut [FileNode]) {
     nodes.sort_by(|a, b| {
         if a.is_dir() && !b.is_dir() {
             std::cmp::Ordering::Less

--- a/src/core/profile_runtime_data.rs
+++ b/src/core/profile_runtime_data.rs
@@ -514,7 +514,7 @@ impl ProfileRuntimeDataOperations for ProfileRuntimeData {
         );
 
         Profile {
-            name: self.profile_name.clone().unwrap_or_else(String::new),
+            name: self.profile_name.clone().unwrap_or_default(),
             root_folder: self.root_path_for_scan.clone(),
             selected_paths: selected_paths_for_profile,
             deselected_paths: deselected_paths_for_profile,

--- a/src/core/profile_runtime_data.rs
+++ b/src/core/profile_runtime_data.rs
@@ -607,6 +607,7 @@ mod tests {
     use std::sync::Mutex;
     use tempfile::{NamedTempFile, tempdir};
 
+type ApplyProfileCall = (HashSet<PathBuf>, HashSet<PathBuf>, Vec<FileNode>);
     /*
      * This module contains unit tests for `ProfileRuntimeData` and its implementation
      * of `ProfileRuntimeDataOperations`. It focuses on testing session state management,
@@ -667,7 +668,7 @@ mod tests {
 
     struct MockStateManager {
         apply_profile_to_tree_calls:
-            Mutex<Vec<(HashSet<PathBuf>, HashSet<PathBuf>, Vec<FileNode>)>>,
+            Mutex<Vec<ApplyProfileCall>>,
         update_folder_selection_calls: Mutex<Vec<(PathBuf, SelectionState)>>,
     }
 
@@ -681,7 +682,7 @@ mod tests {
 
         fn get_apply_profile_to_tree_calls(
             &self,
-        ) -> Vec<(HashSet<PathBuf>, HashSet<PathBuf>, Vec<FileNode>)> {
+        ) -> Vec<ApplyProfileCall> {
             self.apply_profile_to_tree_calls.lock().unwrap().clone()
         }
         fn get_update_folder_selection_calls(&self) -> Vec<(PathBuf, SelectionState)> {

--- a/src/core/profiles.rs
+++ b/src/core/profiles.rs
@@ -350,7 +350,7 @@ mod profile_tests {
                     if path.is_file()
                         && path
                             .extension()
-                            .map_or(false, |ext| ext == PROFILE_FILE_EXTENSION)
+                            .is_some_and(|ext| ext == PROFILE_FILE_EXTENSION)
                     {
                         if let Some(stem) = path.file_stem() {
                             profile_names.push(stem.to_string_lossy().into_owned());
@@ -381,7 +381,7 @@ mod profile_tests {
                     .expect("Pre-test cleanup failed for profile dir");
             }
             // Also remove base if it's empty now, or path_utils will just return it
-            if fs::read_dir(&base_dir).map_or(false, |mut i| i.next().is_none()) {
+            if fs::read_dir(&base_dir).is_ok_and(|mut i| i.next().is_none()) {
                 fs::remove_dir(&base_dir).expect("Pre-test cleanup failed for base dir");
             }
         }

--- a/src/platform_layer/command_executor.rs
+++ b/src/platform_layer/command_executor.rs
@@ -254,7 +254,7 @@ pub(crate) fn execute_set_control_enabled(
         })
     })?;
 
-    if unsafe { EnableWindow(hwnd_ctrl, enabled) }.as_bool() == false {
+    if !unsafe { EnableWindow(hwnd_ctrl, enabled) }.as_bool() {
         // EnableWindow returns non-zero if previously disabled, zero if previously enabled.
         // It doesn't directly indicate error unless GetLastError is checked,
         // but for this operation, we usually assume it succeeds if HWND is valid.
@@ -552,7 +552,7 @@ unsafe extern "system" fn forwarding_panel_proc(
 
         let prev = GetWindowLongPtrW(hwnd, GWLP_USERDATA);
         if prev != 0 {
-            let prev_proc: WNDPROC = std::mem::transmute(prev as isize);
+            let prev_proc: WNDPROC = std::mem::transmute(prev);
             return CallWindowProcW(prev_proc, hwnd, msg, wparam, lparam);
         }
         DefWindowProcW(hwnd, msg, wparam, lparam)
@@ -632,7 +632,7 @@ pub(crate) fn execute_create_panel(
             )?
         };
         unsafe {
-            let prev = SetWindowLongPtrW(hwnd_panel, GWLP_WNDPROC, forwarding_panel_proc as isize);
+            let prev = SetWindowLongPtrW(hwnd_panel, GWLP_WNDPROC, forwarding_panel_proc as usize);
             SetWindowLongPtrW(hwnd_panel, GWLP_USERDATA, prev);
         }
         window_data.register_control_hwnd(panel_id, hwnd_panel);

--- a/src/platform_layer/controls/treeview_handler.rs
+++ b/src/platform_layer/controls/treeview_handler.rs
@@ -826,8 +826,7 @@ pub(crate) fn handle_nm_click(
         return;
     }
     let mut client_pt_for_hittest = screen_pt_of_click;
-    if unsafe { ScreenToClient(hwnd_tv_from_notify, &mut client_pt_for_hittest) }.as_bool() == false
-    {
+    if !unsafe { ScreenToClient(hwnd_tv_from_notify, &mut client_pt_for_hittest) }.as_bool() {
         return;
     }
 

--- a/src/platform_layer/dialog_handler.rs
+++ b/src/platform_layer/dialog_handler.rs
@@ -353,16 +353,16 @@ unsafe extern "system" fn input_dialog_proc(
                     unsafe {
                         EndDialog(hdlg, IDOK.0 as isize).unwrap_or_default();
                     }
-                    return TRUE.0 as isize;
+                    TRUE.0 as isize
                 }
                 x if x == IDCANCEL.0 as u16 => {
                     let dialog_data_ptr =
                         unsafe { GetWindowLongPtrW(hdlg, GWLP_USERDATA) } as *mut InputDialogData;
                     if !dialog_data_ptr.is_null() {
-                        unsafe { (&mut *dialog_data_ptr).success = false };
+                        unsafe { (*dialog_data_ptr).success = false };
                     }
                     unsafe { EndDialog(hdlg, IDCANCEL.0 as isize).unwrap_or_default() };
-                    return TRUE.0 as isize;
+                    TRUE.0 as isize
                 }
                 _ => FALSE.0 as isize, // Message not processed.
             }

--- a/src/platform_layer/window_common.rs
+++ b/src/platform_layer/window_common.rs
@@ -328,7 +328,7 @@ impl NativeWindowData {
                     self.logical_window_id
                 );
                 unsafe {
-                    let _ = DeleteObject(HGDIOBJ(h_font.0 as *mut c_void));
+                    let _ = DeleteObject(HGDIOBJ(h_font.0));
                 }
             }
         }
@@ -708,9 +708,10 @@ impl Win32ApiInternalState {
      * each child control based on its docking style, and then recurses for
      * any children that are themselves containers.
      */
+    #[allow(clippy::only_used_in_recursion)]
     fn apply_layout_rules_for_children(
         self: &Arc<Self>,
-        window_id: WindowId,
+        _window_id: WindowId,
         parent_id_for_layout: Option<i32>,
         parent_rect: RECT,
         window_data: &NativeWindowData,
@@ -1070,7 +1071,7 @@ impl Win32ApiInternalState {
         window_id: WindowId,
     ) -> Option<AppEvent> {
         unsafe {
-            _ = KillTimer(Some(hwnd), timer_id.0 as usize);
+            _ = KillTimer(Some(hwnd), timer_id.0);
         }
         let control_id = timer_id.0 as i32;
 


### PR DESCRIPTION
## Summary
- remove redundant module wrapper in handler tests
- update helper functions to take slices instead of vectors
- derive `Default` for `SelectionState`
- clean up assertions and method calls for clippy
- convert several `map_or` calls to `is_some_and` or `is_ok_and`
- simplify option handling in `ProfileRuntimeData`

## Testing
- `cargo test` *(fails: none)*
- `cargo clippy -- -D warnings` *(fails to run: `rustup` network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684db7695880832cb00ca0db6122c452