### PR TITLE
Remove UI-specific knowledge from platform layer

### DIFF
--- a/doc/Plan.UIDescriptiveLayer.md
+++ b/doc/Plan.UIDescriptiveLayer.md
@@ -64,9 +64,7 @@ This is the **current focus**. The goal is to move all logic for a specific cont
 ### Sub-Phase A.III: Review and Finalize Platform Layer Generality
 
 **Step A.III.1: Review and Remove Residual UI-Specific Knowledge**
-*   **Action:** After all control logic is migrated, perform a thorough review of the entire `platform_layer`.
-*   **Goal:** Ensure no SourcePacker-specific logic, layout assumptions, or control ID knowledge remains. All such specifics must be driven by `PlatformCommand`s. Constants like `ID_TREEVIEW_CTRL` must only be used in `app_logic` and passed into the `platform_layer`.
-*   *Verification:* Code review confirms increased generality. The `platform_layer` acts as a generic command executor and event translator.
+        *   **(Completed)**
 
 **Step A.III.2: Implement Unit Tests for Key Platform Layer Components**
 *   **Goal:** Increase the robustness and maintainability of the `platform_layer` by adding unit tests for its pure logic, independent of the Win32 API. This verifies the correctness of data management and complex algorithms like layout calculation.

--- a/src/app_logic/handler.rs
+++ b/src/app_logic/handler.rs
@@ -1563,7 +1563,7 @@ impl MyAppLogic {
             Some(s) => s,
             None => {
                 log::warn!(
-                    "FilterTextSubmitted received for an unknown or non-main window (ID: {:?}). Ignoring event.",
+                    "InputTextChanged for filter input received for an unknown or non-main window (ID: {:?}). Ignoring event.",
                     window_id
                 );
                 return;
@@ -1719,8 +1719,20 @@ impl PlatformEventHandler for MyAppLogic {
             AppEvent::MainWindowUISetupComplete { window_id } => {
                 self._on_ui_setup_complete(window_id);
             }
-            AppEvent::FilterTextSubmitted { window_id, text } => {
-                self.handle_filter_text_submitted(window_id, text);
+            AppEvent::InputTextChanged {
+                window_id,
+                control_id,
+                text,
+            } => {
+                if control_id == ui_constants::FILTER_INPUT_ID {
+                    self.handle_filter_text_submitted(window_id, text);
+                } else {
+                    log::debug!(
+                        "InputTextChanged received for unhandled control {} in window {:?}",
+                        control_id,
+                        window_id
+                    );
+                }
             }
         }
     }

--- a/src/app_logic/handler_tests.rs
+++ b/src/app_logic/handler_tests.rs
@@ -2195,8 +2195,9 @@ mod handler_tests {
         let filter_text_to_submit = "find_me";
 
         // Act 1: Submit non-empty filter text
-        logic.handle_event(AppEvent::FilterTextSubmitted {
+        logic.handle_event(AppEvent::InputTextChanged {
             window_id,
+            control_id: ui_constants::FILTER_INPUT_ID,
             text: filter_text_to_submit.to_string(),
         });
         let cmds_after_submit = logic.test_drain_commands();
@@ -2225,8 +2226,9 @@ mod handler_tests {
         );
 
         // Act 2: Submit empty filter text (clearing the filter)
-        logic.handle_event(AppEvent::FilterTextSubmitted {
+        logic.handle_event(AppEvent::InputTextChanged {
             window_id,
+            control_id: ui_constants::FILTER_INPUT_ID,
             text: "".to_string(),
         });
         let cmds_after_clear = logic.test_drain_commands();
@@ -2284,8 +2286,9 @@ mod handler_tests {
             .set_snapshot_nodes_for_mock(nodes);
 
         // Act
-        logic.handle_event(AppEvent::FilterTextSubmitted {
+        logic.handle_event(AppEvent::InputTextChanged {
             window_id,
+            control_id: ui_constants::FILTER_INPUT_ID,
             text: "match".to_string(),
         });
         let cmds = logic.test_drain_commands();
@@ -2320,8 +2323,9 @@ mod handler_tests {
         let window_id = WindowId(1);
         logic.test_set_main_window_id_and_init_ui_state(window_id);
 
-        logic.handle_event(AppEvent::FilterTextSubmitted {
+        logic.handle_event(AppEvent::InputTextChanged {
             window_id,
+            control_id: ui_constants::FILTER_INPUT_ID,
             text: "filter".to_string(),
         });
         logic.test_drain_commands();
@@ -2360,8 +2364,9 @@ mod handler_tests {
         let window_id = WindowId(1);
         logic.test_set_main_window_id_and_init_ui_state(window_id);
 
-        logic.handle_event(AppEvent::FilterTextSubmitted {
+        logic.handle_event(AppEvent::InputTextChanged {
             window_id,
+            control_id: ui_constants::FILTER_INPUT_ID,
             text: "abc".into(),
         });
         logic.test_drain_commands();
@@ -2411,15 +2416,17 @@ mod handler_tests {
             .set_snapshot_nodes_for_mock(nodes);
 
         // Act 1: apply matching filter
-        logic.handle_event(AppEvent::FilterTextSubmitted {
+        logic.handle_event(AppEvent::InputTextChanged {
             window_id,
+            control_id: ui_constants::FILTER_INPUT_ID,
             text: "match".into(),
         });
         let _ = logic.test_drain_commands();
 
         // Act 2: apply non-matching filter
-        logic.handle_event(AppEvent::FilterTextSubmitted {
+        logic.handle_event(AppEvent::InputTextChanged {
             window_id,
+            control_id: ui_constants::FILTER_INPUT_ID,
             text: "none".into(),
         });
         let cmds = logic.test_drain_commands();

--- a/src/platform_layer/types.rs
+++ b/src/platform_layer/types.rs
@@ -196,9 +196,10 @@ pub enum AppEvent {
     MainWindowUISetupComplete {
         window_id: WindowId,
     },
-    // Signals that the user has submitted text in a filter input field. TODO: This should be generalized, for any input field.
-    FilterTextSubmitted {
+    // Signals that text was entered in an input control after debouncing.
+    InputTextChanged {
         window_id: WindowId,
+        control_id: i32,
         text: String,
     },
 }

--- a/src/platform_layer/window_common.rs
+++ b/src/platform_layer/window_common.rs
@@ -58,8 +58,8 @@ pub(crate) const WM_APP_TREEVIEW_CHECKBOX_CLICKED: u32 = WM_APP + 0x100;
 pub(crate) const WM_APP_MAIN_WINDOW_UI_SETUP_COMPLETE: u32 = WM_APP + 0x101;
 
 // General UI constants
-pub const STATUS_BAR_HEIGHT: i32 = 25; // Example height for status bar
-pub const FILTER_DEBOUNCE_MS: u32 = 300;
+/// Default debounce delay for edit controls in milliseconds.
+pub const INPUT_DEBOUNCE_MS: u32 = 300;
 
 // Represents an invalid HWND, useful for initialization or checks.
 pub(crate) const HWND_INVALID: HWND = HWND(std::ptr::null_mut());
@@ -1015,7 +1015,7 @@ impl Win32ApiInternalState {
                     SetTimer(
                         Some(_hwnd_parent),
                         command_id as usize,
-                        FILTER_DEBOUNCE_MS,
+                        INPUT_DEBOUNCE_MS,
                         None,
                     );
                 }
@@ -1055,7 +1055,11 @@ impl Win32ApiInternalState {
             let mut buf: [u16; 256] = [0; 256];
             let len = unsafe { GetWindowTextW(hwnd_edit, &mut buf) } as usize;
             let text = String::from_utf16_lossy(&buf[..len]);
-            return Some(AppEvent::FilterTextSubmitted { window_id, text });
+            return Some(AppEvent::InputTextChanged {
+                window_id,
+                control_id,
+                text,
+            });
         }
         None
     }

--- a/src/ui_description_layer.rs
+++ b/src/ui_description_layer.rs
@@ -7,11 +7,8 @@
  */
 use crate::app_logic::ui_constants;
 
-use crate::platform_layer::{
-    types::{
-        DockStyle, LabelClass, LayoutRule, MenuAction, MenuItemConfig, PlatformCommand, WindowId,
-    },
-    window_common::STATUS_BAR_HEIGHT,
+use crate::platform_layer::types::{
+    DockStyle, LabelClass, LayoutRule, MenuAction, MenuItemConfig, PlatformCommand, WindowId,
 };
 
 // Height for the panel containing filter controls.
@@ -19,6 +16,8 @@ pub const FILTER_BAR_HEIGHT: i32 = 30;
 // Fixed width for the "Expand Filtered/All" button.
 pub const FILTER_EXPAND_BUTTON_WIDTH: i32 = 120;
 pub const FILTER_CLEAR_BUTTON_WIDTH: i32 = 30;
+// Fixed height for the status bar at the bottom of the main window.
+pub const STATUS_BAR_HEIGHT: i32 = 25;
 
 /*
  * Generates a list of `PlatformCommand`s that describe the initial static UI layout


### PR DESCRIPTION
## Summary
- drop `STATUS_BAR_HEIGHT` from the platform layer
- rename the filter debounce constant to the generic `INPUT_DEBOUNCE_MS`
- generalize `FilterTextSubmitted` to `InputTextChanged`
- propagate event changes through app logic and tests

## Testing
- `cargo test --quiet`
- `rustup component add rustfmt` *(fails: unsuccessful tunnel)*
- `rustup component add clippy` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_684e660df03c832cbb9781fe8da2bd98