### PR TITLE
Add unit tests for NativeWindowData

### DIFF
--- a/doc/Plan.UIDescriptiveLayer.md
+++ b/doc/Plan.UIDescriptiveLayer.md
@@ -67,18 +67,7 @@ This is the **current focus**. The goal is to move all logic for a specific cont
         *   **(Completed)**
 
 **Step A.III.2: Implement Unit Tests for Key Platform Layer Components**
-*   **Goal:** Increase the robustness and maintainability of the `platform_layer` by adding unit tests for its pure logic, independent of the Win32 API. This verifies the correctness of data management and complex algorithms like layout calculation.
-*   **Strategy:**
-    *   **a. Test `NativeWindowData`:**
-        *   **Action:** Create a `#[cfg(test)] mod tests` module at the bottom of `window_common.rs`.
-        *   **Action:** Write unit tests for `NativeWindowData` methods to verify correct state management. Test cases should cover `register_control_hwnd`, `register_menu_action`, `set_label_severity`, `set_input_background_color`, etc.
-        *   *Justification:* These methods are pure data manipulations and are easy to test, forming a solid foundation.
-    *   **b. Refactor and Test the Layout Engine:**
-        *   **Action:** In `window_common.rs`, refactor `apply_layout_rules_for_children`.
-        *   **Sub-Action 1:** Extract the core calculation logic into a new, pure, private function (e.g., `calculate_layout`). This function will not have any Win32 dependencies. It will take a `RECT` and a slice of `LayoutRule`s and return a `HashMap<i32, RECT>` containing the calculated position and size for each child control.
-        *   **Sub-Action 2:** Simplify the existing `apply_layout_rules_for_children` function. It will now become a "Humble Object" that calls the pure `calculate_layout` function and then iterates through the results, applying them with the impure `MoveWindow` API call.
-        *   **Action:** Write comprehensive unit tests for the new `calculate_layout` function. Test various docking scenarios (`Top`, `Bottom`, `Fill`, `ProportionalFill`), margins, and nested structures to ensure the algorithm is correct.
-*   *Verification:* `cargo test` successfully compiles and runs all new tests in `window_common.rs`. The logic of the layout engine is proven correct without requiring an active window.
+        *   **(Completed)**
 
 **Step A.III.3: Implement Unit Tests for `Win32ApiInternalState`**
 *   **Goal:** Verify the correctness of the platform layer's central state machine (`Win32ApiInternalState` in `app.rs`) by testing its pure logic components.

--- a/src/platform_layer/window_common.rs
+++ b/src/platform_layer/window_common.rs
@@ -1267,7 +1267,7 @@ mod tests {
     fn test_register_control_hwnd_lookup() {
         // Arrange
         let mut data = NativeWindowData::new(WindowId(1));
-        let hwnd = HWND(0x1234 as isize);
+        let hwnd = HWND(0x1234 as *mut std::ffi::c_void);
         // Act
         data.register_control_hwnd(42, hwnd);
         // Assert
@@ -1326,4 +1326,3 @@ mod tests {
         assert!(!state.brush.is_invalid());
     }
 }
-

--- a/src/platform_layer/window_common.rs
+++ b/src/platform_layer/window_common.rs
@@ -317,14 +317,19 @@ impl NativeWindowData {
         }
         child_rules.sort_by_key(|r| r.order);
 
-        if child_rules.iter().filter(|r| r.dock_style == DockStyle::Fill).count() > 1 {
+        if child_rules
+            .iter()
+            .filter(|r| r.dock_style == DockStyle::Fill)
+            .count()
+            > 1
+        {
             log::warn!(
                 "Layout: Multiple Fill controls for parent_id {:?}. Using first.",
                 parent_id_for_layout
             );
         }
 
-        let layout_map = calculate_layout(parent_rect, &child_rules);
+        let layout_map = NativeWindowData::calculate_layout(parent_rect, &child_rules);
 
         for rule in &child_rules {
             let rect = match layout_map.get(&rule.control_id) {


### PR DESCRIPTION
## Summary
- add tests exercising NativeWindowData data management

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684e6afec8b8832cb0ae3b32851c9bac