### PR TITLE
Add NewProfile menu action enum

### DIFF
--- a/src/app_logic/handler.rs
+++ b/src/app_logic/handler.rs
@@ -680,6 +680,24 @@ impl MyAppLogic {
             });
     }
 
+    /*
+     * Initiates the two-step flow for creating a brand new profile when the user
+     * selects "File/New Profile". Requires an active main window to present the
+     * dialogs for entering the profile name and root folder.
+     */
+    fn handle_menu_new_profile_clicked(&mut self) {
+        let window_id = match self.ui_state.as_ref().map(|s| s.window_id) {
+            Some(id) => id,
+            None => {
+                log::warn!("Cannot handle NewProfile: No UI state (main window).");
+                return;
+            }
+        };
+
+        log::debug!("MenuAction::NewProfile action received by AppLogic.");
+        self.start_new_profile_creation_flow(window_id);
+    }
+
     fn handle_file_open_dialog_completed(&mut self, window_id: WindowId, result: Option<PathBuf>) {
         if !self
             .ui_state
@@ -1675,6 +1693,7 @@ impl PlatformEventHandler for MyAppLogic {
             }
             AppEvent::MenuActionClicked { action } => match action {
                 MenuAction::LoadProfile => self.handle_menu_load_profile_clicked(),
+                MenuAction::NewProfile => self.handle_menu_new_profile_clicked(),
                 MenuAction::SaveProfileAs => self.handle_menu_save_profile_as_clicked(),
                 MenuAction::SetArchivePath => self.handle_menu_set_archive_path_clicked(),
                 MenuAction::RefreshFileList => self.handle_menu_refresh_file_list_clicked(),

--- a/src/app_logic/handler.rs
+++ b/src/app_logic/handler.rs
@@ -681,9 +681,11 @@ impl MyAppLogic {
     }
 
     /*
-     * Initiates the two-step flow for creating a brand new profile when the user
-     * selects "File/New Profile". Requires an active main window to present the
-     * dialogs for entering the profile name and root folder.
+     * Starts the first step of the profile creation sequence when the user
+     * chooses "File/New Profile".
+     *
+     * An active main window is required so the dialogs for entering the profile
+     * name and selecting the root folder can be displayed.
      */
     fn handle_menu_new_profile_clicked(&mut self) {
         let window_id = match self.ui_state.as_ref().map(|s| s.window_id) {

--- a/src/platform_layer/types.rs
+++ b/src/platform_layer/types.rs
@@ -38,6 +38,7 @@ pub struct TreeItemId(pub u64);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum MenuAction {
     LoadProfile,
+    NewProfile,
     SaveProfileAs,
     SetArchivePath,
     RefreshFileList,

--- a/src/ui_description_layer.rs
+++ b/src/ui_description_layer.rs
@@ -43,6 +43,11 @@ pub fn build_main_window_static_layout(window_id: WindowId) -> Vec<PlatformComma
             children: Vec::new(),
         },
         MenuItemConfig {
+            action: Some(MenuAction::NewProfile),
+            text: "New Profile...".to_string(),
+            children: Vec::new(),
+        },
+        MenuItemConfig {
             action: Some(MenuAction::SaveProfileAs),
             text: "Save Profile As...".to_string(),
             children: Vec::new(),


### PR DESCRIPTION
## Summary
- extend `MenuAction` with `NewProfile` variant

## Testing
- `cargo test` *(fails: pattern `MenuAction::NewProfile` not covered)*
- `cargo fmt` *(fails: rustfmt not installed)*
- `cargo clippy` *(fails: clippy not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684eb4a626fc832cb5d07fec69e30e7a